### PR TITLE
Add unit tests for assembler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ bbb: $(BUILD)/machine.o $(BUILD)/memory.o $(BUILD)/io.o $(BUILD)/sim.o $(BUILD)/
 build:
 	mkdir -p $(BUILD)
 
-test: $(BUILD)/munit.o $(BUILD)/machine.o $(BUILD)/memory.o $(BUILD)/io.o $(BUILD)/table.o $(BUILD)/assem.o $(SRC)/test/* $(SRC)/test.c
+test: $(BUILD)/munit.o $(BUILD)/machine.o $(BUILD)/memory.o $(BUILD)/io.o $(BUILD)/table.o $(BUILD)/assem.o $(SRC)/test/*.c $(SRC)/test.c
 	$(COMPILE) $^ -o $@
 
 $(BUILD)/munit.o: $(SRC)/munit/munit.c $(SRC)/munit/munit.h

--- a/src/assem/assem.c
+++ b/src/assem/assem.c
@@ -1,17 +1,16 @@
 #include "assem.h"
+#include "../assem/table.h"
+#include "../machine/cpu.h"
+#include "../machine/memory.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include "../machine/cpu.h"
-#include "../machine/memory.h"
-#include "../assem/table.h"
 
 #define OPCODE_COUNT 16
 #define REGISTER_COUNT 13
 #define DIRECTIVE_COUNT 3
 
-typedef enum ParseState
-{
+typedef enum ParseState {
     PARSE_OPER,
     PARSE_TEST,
     PARSE_ADDR,
@@ -24,13 +23,7 @@ typedef enum ParseState
     PARSE_ERROR = 0xFF
 } ParseState;
 
-typedef enum
-{
-    META_ORG,
-    META_DATA,
-    META_INCLUDE,
-    META_ERROR
-} MetaDirective;
+typedef enum { META_ORG, META_DATA, META_INCLUDE, META_ERROR } MetaDirective;
 
 #define OFFSET_SRC 12
 #define OFFSET_DEST 8
@@ -42,22 +35,23 @@ typedef enum
 #define DATA_OFFSET(ctx) ((ctx)->data - (ctx)->data_start)
 
 ParseState next_state[OPCODE_COUNT] = {
-    PARSE_DONE, PARSE_DEST, PARSE_DEST, PARSE_OPER_SRC, PARSE_OPER_SRC, PARSE_DEST,
-    PARSE_DEST, PARSE_OPER_SRC, PARSE_OPER_SRC, PARSE_OPER_SRC, PARSE_OPER_SRC, PARSE_PUSH_SRC,
-    PARSE_DEST, PARSE_TEST, PARSE_TEST, PARSE_OPER_SRC};
+    PARSE_DONE,     PARSE_DEST,     PARSE_DEST,     PARSE_OPER_SRC,
+    PARSE_OPER_SRC, PARSE_DEST,     PARSE_DEST,     PARSE_OPER_SRC,
+    PARSE_OPER_SRC, PARSE_OPER_SRC, PARSE_OPER_SRC, PARSE_PUSH_SRC,
+    PARSE_DEST,     PARSE_TEST,     PARSE_TEST,     PARSE_OPER_SRC};
 
-typedef struct context
-{
+typedef struct context {
     uint8_t *data_start;
     uint8_t *data;
     table *symbols;
     uint32_t line;
 } context;
 
-char *opcodes[OPCODE_COUNT] = {"NOP", "INC", "DEC", "ADD", "SUB", "RLC", "RRC", "AND",
-                               "OR", "XOR", "CMP", "PSH", "POP", "JMP", "JSR", "MOV"};
+char *opcodes[OPCODE_COUNT] = {"NOP", "INC", "DEC", "ADD", "SUB", "RLC",
+                               "RRC", "AND", "OR",  "XOR", "CMP", "PSH",
+                               "POP", "JMP", "JSR", "MOV"};
 
-char *registers[REGISTER_COUNT] = {"a", "b", "c", "d", "e", "f", "s0",
+char *registers[REGISTER_COUNT] = {"a",  "b",  "c",  "d",  "e",  "f", "s0",
                                    "s1", "pc", "sp", "iv", "ix", "ta"};
 // The CV, MD, and MX virtual registers are missing from this table
 // because they cannot be used in register specifiers.
@@ -66,13 +60,12 @@ char *directives[DIRECTIVE_COUNT] = {"org", "data", "inc"};
 
 #define PUSH_NEXT(m, v) (*(m)++ = (v))
 
-#define PUSH_QUARTET(m, v)             \
-    do                                 \
-    {                                  \
-        *(m)++ = ((v) & 0xF000) >> 12; \
-        *(m)++ = ((v) & 0xF00) >> 8;   \
-        *(m)++ = ((v) & 0xF0) >> 4;    \
-        *(m)++ = ((v) & 0xF);          \
+#define PUSH_QUARTET(m, v)                                                     \
+    do {                                                                       \
+        *(m)++ = ((v) & 0xF000) >> 12;                                         \
+        *(m)++ = ((v) & 0xF00) >> 8;                                           \
+        *(m)++ = ((v) & 0xF0) >> 4;                                            \
+        *(m)++ = ((v) & 0xF);                                                  \
     } while (0)
 
 #define UPDATE_STATE(st, v) ((st) & ~MASK_PARSE_STATE | (v))
@@ -90,18 +83,18 @@ static inline bool parse_label(char *);
 
 bool tokenize(context *, char *, uint16_t);
 
-memory *build_image(char *filename, char *prog)
-{
+memory *build_image(char *filename, char *prog) {
     memory *mem = memory_init(CPU_MAX_ADDRESS);
     table *symbols = table_init();
 
-    context ctx = {.data_start = mem->data, .data = mem->data, .symbols = symbols, .line = 0};
+    context ctx = {.data_start = mem->data,
+                   .data = mem->data,
+                   .symbols = symbols,
+                   .line = 0};
 
-    for (char *l = strsep(&prog, "\n"); l != NULL; l = strsep(&prog, "\n"))
-    {
+    for (char *l = strsep(&prog, "\n"); l != NULL; l = strsep(&prog, "\n")) {
         char *line = strdup(l);
-        if (!tokenize(&ctx, line, ++ctx.line))
-        {
+        if (!tokenize(&ctx, line, ++ctx.line)) {
             fprintf(stderr, "%s:%d: %s\n", filename, ctx.line, l);
             break;
         }
@@ -110,52 +103,27 @@ memory *build_image(char *filename, char *prog)
 
     // table_print(symbols);
 
-    for (reference *r = table_ref_pop(symbols); r != NULL; r = table_ref_pop(symbols))
-    {
+    for (reference *r = table_ref_pop(symbols); r != NULL;
+         r = table_ref_pop(symbols)) {
         symbol *s = table_symbol_lookup(symbols, r->label);
 
-        if (s)
-        {
+        if (s) {
             uint16_t addr = s->address;
             *(r->offset + 0) = (addr >> 12) & 0xF;
             *(r->offset + 1) = (addr >> 8) & 0xF;
             *(r->offset + 2) = (addr >> 4) & 0xF;
             *(r->offset + 3) = (addr >> 0) & 0xF;
-        }
-        else
-        {
-            fprintf(stderr, "error: reference to undefined symbol '%s'\n", r->label);
+        } else {
+            fprintf(stderr, "error: reference to undefined symbol '%s'\n",
+                    r->label);
             return NULL;
-        }
-    }
-
-    // printf("\nIMAGE\n-------------------  -------------------\n");
-
-    // size_t len = ctx.data - mem->data;
-
-    for (size_t i = 0; i < 512; i++)
-    {
-        printf("%0X", mem->data[i]);
-
-        if (i % 32 == 31)
-        {
-            printf("\n");
-        }
-        else if (i % 16 == 15)
-        {
-            printf("  ");
-        }
-        else if (i % 4 == 3)
-        {
-            printf(" ");
         }
     }
 
     return mem;
 }
 
-bool tokenize(context *ctx, char *line, uint16_t num)
-{
+bool tokenize(context *ctx, char *line, uint16_t num) {
     char *delim = "\t ";
     char *close = ")";
     char *sep = delim;
@@ -167,40 +135,38 @@ bool tokenize(context *ctx, char *line, uint16_t num)
     char *src_label;
     char *dst_label;
 
-    for (char *t = strtok_r(line, sep, &saveptr); t != NULL; t = strtok_r(NULL, sep, &saveptr))
-    {
+    for (char *t = strtok_r(line, sep, &saveptr); t != NULL;
+         t = strtok_r(NULL, sep, &saveptr)) {
         size_t length = strlen(t);
 
         src_label = NULL;
         dst_label = NULL;
 
-        if (t[0] == '(')
-        {
-            // If we encounter an opening parenthesis, the tokenizer must ignore all characters
-            // until the closing parenthesis. If the final character of the current token is not the
-            // closing parenthesis, switch the separator in the strtok call to ")". Then the next
+        if (t[0] == '(') {
+            // If we encounter an opening parenthesis, the tokenizer must ignore
+            // all characters until the closing parenthesis. If the final
+            // character of the current token is not the closing parenthesis,
+            // switch the separator in the strtok call to ")". Then the next
             // token will be the remainder of the comment.
-            if (t[length - 1] != ')')
-            {
+            if (t[length - 1] != ')') {
                 sep = close;
             }
 
             continue;
-        }
-        else if (strcmp(sep, close) == 0)
-        {
-            // If we enter the loop when the separator is set to ")", it indicates we've parsed to
-            // the end of the comment and should swap the separator back.
+        } else if (strcmp(sep, close) == 0) {
+            // If we enter the loop when the separator is set to ")", it
+            // indicates we've parsed to the end of the comment and should swap
+            // the separator back.
             sep = delim;
             continue;
         }
 
-        if (t[0] == '#')
-        {
-            // Assembler directives start with '#' and should be the first token on a line.
-            if ((st & MASK_PARSE_STATE) != PARSE_OPER)
-            {
-                fprintf(stderr, "error: didn't expect an assembler directive here\n");
+        if (t[0] == '#') {
+            // Assembler directives start with '#' and should be the first token
+            // on a line.
+            if ((st & MASK_PARSE_STATE) != PARSE_OPER) {
+                fprintf(stderr,
+                        "error: didn't expect an assembler directive here\n");
                 return false;
             }
 
@@ -208,94 +174,71 @@ bool tokenize(context *ctx, char *line, uint16_t num)
             continue;
         }
 
-        if (t[length - 1] == ':')
-        {
-            // Label definitions start with a letter or underscore followed by letters, numbers,
-            // or underscores and end with ':'. If we encounter one, we need to define it in the
-            // symbol table.
+        if (t[length - 1] == ':') {
+            // Label definitions start with a letter or underscore followed by
+            // letters, numbers, or underscores and end with ':'. If we
+            // encounter one, we need to define it in the symbol table.
             t[length - 1] = '\0';
             table_symbol_define(ctx->symbols, t, DATA_OFFSET(ctx));
             continue;
         }
 
-        switch (st & MASK_PARSE_STATE)
-        {
-        case PARSE_OPER:
-        {
+        switch (st & MASK_PARSE_STATE) {
+        case PARSE_OPER: {
             st = UPDATE_STATE(st, parse_opcode(ctx, t));
             break;
         }
-        case PARSE_TEST:
-        {
+        case PARSE_TEST: {
             st = UPDATE_STATE(st, parse_condition(ctx, t));
             break;
         }
-        case PARSE_ADDR:
-        {
-            if (parse_addr(ctx, t, &dst_ext, &dst_label))
-            {
-                st = UPDATE_STATE(st, PARSE_DONE | (REGISTER_MD << OFFSET_DEST));
-            }
-            else
-            {
+        case PARSE_ADDR: {
+            if (parse_addr(ctx, t, &dst_ext, &dst_label)) {
+                st =
+                    UPDATE_STATE(st, PARSE_DONE | (REGISTER_MD << OFFSET_DEST));
+            } else {
                 fprintf(stderr, "error: expected address, found '%s'\n", t);
             }
             break;
         }
-        case PARSE_DEST:
-        {
+        case PARSE_DEST: {
             st = UPDATE_STATE(st, parse_dest(ctx, t, &dst_ext, &dst_label));
             break;
         }
-        case PARSE_OPER_SRC:
-        {
+        case PARSE_OPER_SRC: {
             st = UPDATE_STATE(st, parse_src(ctx, t, &src_ext, &src_label));
             break;
         }
-        case PARSE_PUSH_SRC:
-        {
+        case PARSE_PUSH_SRC: {
             st = UPDATE_STATE(st, parse_src(ctx, t, &src_ext, &src_label));
-            if ((st & MASK_PARSE_STATE) != PARSE_ERROR)
-            {
+            if ((st & MASK_PARSE_STATE) != PARSE_ERROR) {
                 st = UPDATE_STATE(st, PARSE_DONE);
             }
             break;
         }
-        case PARSE_ORG_ADDR:
-        {
+        case PARSE_ORG_ADDR: {
             uint16_t offset = 0;
 
-            if (parse_hex(t, 4, &offset))
-            {
+            if (parse_hex(t, 4, &offset)) {
                 ctx->data = ctx->data_start + offset;
                 st = UPDATE_STATE(st, PARSE_DONE);
-            }
-            else
-            {
+            } else {
                 fprintf(stderr, "error: expected address, found '%s'\n", t);
             }
 
             break;
         }
-        case PARSE_DATA:
-        {
+        case PARSE_DATA: {
             uint16_t data = 0;
 
-            if (parse_hex(t, 1, &data))
-            {
+            if (parse_hex(t, 1, &data)) {
                 PUSH_NEXT(ctx->data, data & 0xF);
-            }
-            else if (parse_hex(t, 2, &data))
-            {
+            } else if (parse_hex(t, 2, &data)) {
                 PUSH_NEXT(ctx->data, data & 0xF);
                 PUSH_NEXT(ctx->data, data >> 2 & 0xF);
-            }
-            else if (parse_hex(t, 4, &data))
-            {
+            } else if (parse_hex(t, 4, &data)) {
                 PUSH_QUARTET(ctx->data, data);
-            }
-            else
-            {
+            } else {
                 fprintf(stderr, "error: expected address, found '%s'\n", t);
             }
 
@@ -305,42 +248,36 @@ bool tokenize(context *ctx, char *line, uint16_t num)
             break;
         }
 
-        if ((st & MASK_PARSE_STATE) == PARSE_ERROR)
-        {
+        if ((st & MASK_PARSE_STATE) == PARSE_ERROR) {
             // Stop parsing the line if we encountered an error
             break;
         }
 
-        if ((st & MASK_PARSE_STATE) == PARSE_DONE)
-        {
-            int virt_register_mask = (REGISTER_CV & REGISTER_MD & REGISTER_MX);
+        if ((st & MASK_PARSE_STATE) == PARSE_DONE) {
+            int virt_register_mask =
+                (1 << REGISTER_CV) | (1 << REGISTER_MD) | (1 << REGISTER_MX);
             uint8_t source = (st & MASK_SRC_REGISTER) >> OFFSET_SRC;
             uint8_t dest = (st & MASK_DST_REGISTER) >> OFFSET_DEST;
 
-            if ((source & virt_register_mask) == virt_register_mask)
-            {
-                if (src_label)
-                {
+            if (((1 << source) & virt_register_mask) == (1 << source)) {
+                if (src_label) {
                     table_ref_add(ctx->symbols, src_label, ctx->data);
                 }
 
-                if (source == REGISTER_CV && dest < REGISTER_PC)
-                {
-                    // We only want to push one word of data when a constant value's destination
-                    // is a 4-bit general purpose register.
+                if (source == REGISTER_CV &&
+                    (dest < REGISTER_PC || dest > REGISTER_CV)) {
+                    // We only want to push one word of data when a constant
+                    // value's destination is a 4-bit general purpose register,
+                    // a memory direct address, or a memory index address.
                     PUSH_NEXT(ctx->data, src_ext & 0xF);
-                }
-                else
-                {
+                } else {
                     // In all other cases, we push four words of data.
                     PUSH_QUARTET(ctx->data, src_ext);
                 }
             }
 
-            if ((dest & virt_register_mask) == virt_register_mask)
-            {
-                if (dst_label)
-                {
+            if (((1 << dest) & virt_register_mask) == (1 << dest)) {
+                if (dst_label) {
                     table_ref_add(ctx->symbols, dst_label, ctx->data);
                 }
 
@@ -351,29 +288,24 @@ bool tokenize(context *ctx, char *line, uint16_t num)
 
     int state = st & MASK_PARSE_STATE;
 
-    if (state == PARSE_OPER || state == PARSE_DONE || state == PARSE_DATA)
-    {
+    if (state == PARSE_OPER || state == PARSE_DONE || state == PARSE_DATA) {
         return true;
     }
 
     return false;
 }
 
-static inline ParseState parse_directive(context *ctx, char *token)
-{
+static inline ParseState parse_directive(context *ctx, char *token) {
     MetaDirective dir = META_ERROR;
 
-    for (size_t i = 0; i < DIRECTIVE_COUNT; i++)
-    {
-        if (strcmp(token, directives[i]) == 0)
-        {
+    for (size_t i = 0; i < DIRECTIVE_COUNT; i++) {
+        if (strcmp(token, directives[i]) == 0) {
             dir = i;
             break;
         }
     }
 
-    switch (dir)
-    {
+    switch (dir) {
     case META_ORG:
         return PARSE_ORG_ADDR;
     case META_DATA:
@@ -381,17 +313,15 @@ static inline ParseState parse_directive(context *ctx, char *token)
     // TODO: add case META_INC:
     case META_ERROR:
     default:
-        fprintf(stderr, "error: unrecognized assembler directive '%s'\n", token);
+        fprintf(stderr, "error: unrecognized assembler directive '%s'\n",
+                token);
         return PARSE_ERROR;
     }
 }
 
-static inline ParseState parse_opcode(context *ctx, char *token)
-{
-    for (uint8_t opcode = 0; opcode <= 0xF; opcode++)
-    {
-        if (strcmp(token, opcodes[opcode]) == 0)
-        {
+static inline ParseState parse_opcode(context *ctx, char *token) {
+    for (uint8_t opcode = 0; opcode <= 0xF; opcode++) {
+        if (strcmp(token, opcodes[opcode]) == 0) {
             PUSH_NEXT(ctx->data, opcode);
             return next_state[opcode];
         }
@@ -401,11 +331,10 @@ static inline ParseState parse_opcode(context *ctx, char *token)
     return PARSE_ERROR;
 }
 
-static inline ParseState parse_condition(context *ctx, char *token)
-{
-    if (token[1] != '=' || (token[2] != '0' && token[2] != '1'))
-    {
-        fprintf(stderr, "error: encountered unrecognized condition '%s'\n", token);
+static inline ParseState parse_condition(context *ctx, char *token) {
+    if (token[1] != '=' || (token[2] != '0' && token[2] != '1')) {
+        fprintf(stderr, "error: encountered unrecognized condition '%s'\n",
+                token);
         return PARSE_ERROR;
     }
 
@@ -413,10 +342,8 @@ static inline ParseState parse_condition(context *ctx, char *token)
 
     char *bitfield = "NZCOIH01";
 
-    for (uint8_t t = 0; t < 8; t++)
-    {
-        if (token[0] == bitfield[t])
-        {
+    for (uint8_t t = 0; t < 8; t++) {
+        if (token[0] == bitfield[t]) {
             PUSH_NEXT(ctx->data, test | t);
             return PARSE_ADDR;
         }
@@ -426,48 +353,43 @@ static inline ParseState parse_condition(context *ctx, char *token)
     return PARSE_ERROR;
 }
 
-static inline ParseState parse_src(context *ctx, char *token, uint16_t *ext, char **label)
-{
+static inline ParseState parse_src(context *ctx, char *token, uint16_t *ext,
+                                   char **label) {
     uint8_t reg;
 
-    if (token[0] == '%')
-    {
-        if (parse_register(ctx, &token[1], &reg))
-        {
+    if (token[0] == '%') {
+        if (parse_register(ctx, &token[1], &reg)) {
             return PARSE_DEST | (reg << OFFSET_SRC);
-        }
-        else
-        {
+        } else {
             fprintf(stderr, "error: unrecognized register '%s'\n", token);
             return PARSE_ERROR;
         }
-    }
-    else if (token[0] == '0' && token[1] == 'x')
-    {
-        if (parse_hex(&token[2], 4, ext))
-        {
+    } else if (token[0] == '0' && token[1] == 'x') {
+        if (parse_hex(&token[2], 4, ext)) {
             PUSH_NEXT(ctx->data, REGISTER_CV);
             return PARSE_DEST | (REGISTER_CV << OFFSET_SRC);
-        }
-        else if (parse_hex(&token[2], 1, ext))
-        {
+        } else if (parse_hex(&token[2], 1, ext)) {
             PUSH_NEXT(ctx->data, REGISTER_CV);
             return PARSE_DEST | (REGISTER_CV << OFFSET_SRC);
-        }
-        else
-        {
+        } else {
             fprintf(stderr, "error: unable to parse hex literal '%s'\n", token);
             return PARSE_ERROR;
         }
     }
 
-    if (parse_addr(ctx, token, ext, label))
-    {
-        PUSH_NEXT(ctx->data, REGISTER_MD);
+    if (parse_addr(ctx, token, ext, label)) {
+        switch (token[0]) {
+        case '@': {
+            PUSH_NEXT(ctx->data, REGISTER_MD);
+            break;
+        }
+        case '*': {
+            PUSH_NEXT(ctx->data, REGISTER_MX);
+            break;
+        }
+        }
         return PARSE_DEST | (REGISTER_MD << OFFSET_SRC);
-    }
-    else if (parse_int(token, ext))
-    {
+    } else if (parse_int(token, ext)) {
         PUSH_NEXT(ctx->data, REGISTER_CV);
         return PARSE_DEST | (REGISTER_CV << OFFSET_SRC);
     }
@@ -476,41 +398,41 @@ static inline ParseState parse_src(context *ctx, char *token, uint16_t *ext, cha
     return PARSE_ERROR;
 }
 
-static inline ParseState parse_dest(context *ctx, char *token, uint16_t *ext, char **label)
-{
+static inline ParseState parse_dest(context *ctx, char *token, uint16_t *ext,
+                                    char **label) {
     uint8_t reg;
 
-    if (token[0] == '%')
-    {
-        if (parse_register(ctx, &token[1], &reg))
-        {
+    if (token[0] == '%') {
+        if (parse_register(ctx, &token[1], &reg)) {
             return PARSE_DONE | (reg << OFFSET_DEST);
-        }
-        else
-        {
+        } else {
             fprintf(stderr, "error: unrecognized register '%s'\n", token);
             return PARSE_ERROR;
         }
     }
 
-    if (parse_addr(ctx, token, ext, label))
-    {
-        PUSH_NEXT(ctx->data, REGISTER_MD);
+    if (parse_addr(ctx, token, ext, label)) {
+        switch (token[0]) {
+        case '@': {
+            PUSH_NEXT(ctx->data, REGISTER_MD);
+            break;
+        }
+        case '*': {
+            PUSH_NEXT(ctx->data, REGISTER_MX);
+            break;
+        }
+        }
         return PARSE_DONE | (REGISTER_MD << OFFSET_DEST);
-    }
-    else
-    {
-        fprintf(stderr, "error: unable to parse destination operand '%s'\n", token);
+    } else {
+        fprintf(stderr, "error: unable to parse destination operand '%s'\n",
+                token);
         return PARSE_ERROR;
     }
 }
 
-static inline bool parse_register(context *ctx, char *token, uint8_t *reg)
-{
-    for (uint8_t r = 0; r < REGISTER_COUNT; r++)
-    {
-        if (strcmp(token, registers[r]) == 0)
-        {
+static inline bool parse_register(context *ctx, char *token, uint8_t *reg) {
+    for (uint8_t r = 0; r < REGISTER_COUNT; r++) {
+        if (strcmp(token, registers[r]) == 0) {
             PUSH_NEXT(ctx->data, r);
             *reg = r;
             return true;
@@ -520,46 +442,33 @@ static inline bool parse_register(context *ctx, char *token, uint8_t *reg)
     return false;
 }
 
-static inline bool parse_addr(context *ctx, char *token, uint16_t *addr, char **label)
-{
-    switch (token[0])
-    {
-    case '@':
-    {
+static inline bool parse_addr(context *ctx, char *token, uint16_t *addr,
+                              char **label) {
+    switch (token[0]) {
+    case '@': {
         // Memory direct address
-        if (parse_hex(&token[1], 4, addr))
-        {
+        if (parse_hex(&token[1], 4, addr)) {
             return true;
-        }
-        else
-        {
+        } else {
             fprintf(stderr, "error: expected hex address, found '%s'\n", token);
             return false;
         }
     }
-    case '*':
-    {
+    case '*': {
         // Memory indexed
-        if (parse_hex(&token[1], 4, addr))
-        {
+        if (parse_hex(&token[1], 4, addr)) {
             return true;
-        }
-        else
-        {
+        } else {
             fprintf(stderr, "error: expected hex address, found '%s'\n", token);
             return false;
         }
     }
-    case '.':
-    {
+    case '.': {
         // Label reference
-        if (parse_label(&token[1]))
-        {
+        if (parse_label(&token[1])) {
             *label = &token[1];
             return true;
-        }
-        else
-        {
+        } else {
             fprintf(stderr, "error: expected label, found '%s'\n", token);
             return false;
         }
@@ -569,24 +478,17 @@ static inline bool parse_addr(context *ctx, char *token, uint16_t *addr, char **
     }
 }
 
-static inline bool parse_hex(char *token, uint8_t length, uint16_t *result)
-{
+static inline bool parse_hex(char *token, uint8_t length, uint16_t *result) {
     *result = 0;
 
-    for (char *ch = token; *ch != 0; ch++)
-    {
+    for (char *ch = token; *ch != 0; ch++) {
         *result <<= 4;
         length--;
-        if (*ch >= '0' && *ch <= '9')
-        {
+        if (*ch >= '0' && *ch <= '9') {
             *result += (*ch - '0');
-        }
-        else if (*ch >= 'A' && *ch <= 'F')
-        {
+        } else if (*ch >= 'A' && *ch <= 'F') {
             *result += (*ch - 'A') + 0xA;
-        }
-        else
-        {
+        } else {
             return false;
         }
     }
@@ -594,19 +496,14 @@ static inline bool parse_hex(char *token, uint8_t length, uint16_t *result)
     return length == 0;
 }
 
-static inline bool parse_int(char *token, uint16_t *result)
-{
+static inline bool parse_int(char *token, uint16_t *result) {
     *result = 0;
 
-    for (char *ch = token; *ch != 0; ch++)
-    {
+    for (char *ch = token; *ch != 0; ch++) {
         *result *= 10;
-        if (*ch >= '0' && *ch <= '9')
-        {
+        if (*ch >= '0' && *ch <= '9') {
             *result += (*ch - '0');
-        }
-        else
-        {
+        } else {
             return false;
         }
     }
@@ -614,17 +511,15 @@ static inline bool parse_int(char *token, uint16_t *result)
     return true;
 }
 
-static inline bool parse_label(char *token)
-{
-    // Parsing a label involves validating the characters and then scanning the label list for
-    // the current label. If the label is found, we set the result value to the pointer into the
-    // label list. If the label is not found, we add the label and return the pointer to the
-    // newly added label.
+static inline bool parse_label(char *token) {
+    // Parsing a label involves validating the characters and then scanning the
+    // label list for the current label. If the label is found, we set the
+    // result value to the pointer into the label list. If the label is not
+    // found, we add the label and return the pointer to the newly added label.
 
-    for (char *ch = token; *ch != 0; ch++)
-    {
-        if (!((*ch >= 'A' && *ch <= 'Z') || (*ch >= 'a' && *ch <= 'z') || (*ch == '_')))
-        {
+    for (char *ch = token; *ch != 0; ch++) {
+        if (!((*ch >= 'A' && *ch <= 'Z') || (*ch >= 'a' && *ch <= 'z') ||
+              (*ch == '_'))) {
             return false;
         }
     }

--- a/src/machine/cpu.c
+++ b/src/machine/cpu.c
@@ -24,6 +24,7 @@ static inline void machine_instr_execute(machine *m);
 
 static inline void machine_interrupt_check(machine *m);
 void machine_call_update(machine *m);
+void machine_call_teardown(machine *m);
 
 static inline uint16_t machine_get_value(machine *m, Register src,
                                          uint16_t src_ext) {
@@ -141,6 +142,12 @@ void machine_run(machine *m) {
 void machine_call_update(machine *m) {
     if (m->event_update != NULL) {
         m->event_update(m);
+    }
+}
+
+void machine_call_teardown(machine *m) {
+    if (m->event_teardown != NULL) {
+        m->event_teardown(m);
     }
 }
 
@@ -458,6 +465,7 @@ static inline void machine_instr_execute(machine *m) {
 }
 
 void machine_free(machine *m) {
+    machine_call_teardown(m);
     memory_free(m->memory);
     free(m);
 }

--- a/src/machine/memory.c
+++ b/src/machine/memory.c
@@ -13,7 +13,7 @@ memory *memory_init(size_t size) {
 }
 
 uint8_t memory_read(memory *mem, size_t address) {
-    if (address > mem->size) {
+    if (address >= mem->size) {
         return 0;
     }
 
@@ -24,7 +24,7 @@ uint8_t memory_read_indexed(memory *mem, uint8_t *index, size_t offset) {
     // TODO: The pointer math here is very likely wrong...
     size_t address = (index - mem->data) + offset;
 
-    if (address > mem->size) {
+    if (address >= mem->size) {
         return 0;
     }
 
@@ -32,7 +32,7 @@ uint8_t memory_read_indexed(memory *mem, uint8_t *index, size_t offset) {
 }
 
 bool memory_write(memory *mem, size_t address, uint8_t value) {
-    if (address > mem->size) {
+    if (address >= mem->size) {
         return false;
     }
 
@@ -40,11 +40,12 @@ bool memory_write(memory *mem, size_t address, uint8_t value) {
     return true;
 };
 
-bool memory_write_indexed(memory *mem, uint8_t *index, size_t offset, uint8_t value) {
+bool memory_write_indexed(memory *mem, uint8_t *index, size_t offset,
+                          uint8_t value) {
     // TODO: The pointer math here is very likely wrong...
     size_t address = (index - mem->data) + offset;
 
-    if (address > mem->size) {
+    if (address >= mem->size) {
         return false;
     }
 

--- a/src/test.c
+++ b/src/test.c
@@ -1,11 +1,17 @@
 #define MUNIT_ENABLE_ASSERT_ALIASES
 #include "munit/munit.h"
+#include "test/test_assem.c"
+#include "test/test_build.c"
 #include "test/test_cpu.c"
 #include "test/test_memory.c"
 #include "test/test_table.c"
 
 MunitSuite suites[] = { // Comment here to force formatting
     {(char *)"assem/table: ", assem_table_tests, NULL, 1,
+     MUNIT_SUITE_OPTION_NONE},
+    {(char *)"assem/assem: ", assem_assem_tests, NULL, 1,
+     MUNIT_SUITE_OPTION_NONE},
+    {(char *)"assem/build: ", assem_build_tests, NULL, 1,
      MUNIT_SUITE_OPTION_NONE},
     {(char *)"machine/memory: ", machine_memory_tests, NULL, 1,
      MUNIT_SUITE_OPTION_NONE},

--- a/src/test/test_assem.c
+++ b/src/test/test_assem.c
@@ -1,0 +1,823 @@
+#include <memory.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../assem/assem.h"
+#include "../machine/cpu.h"
+#include "../munit/munit.h"
+#include "./test_assem.h"
+
+#define ASSEM_MAX_ADDRESS (64 * 1024)
+
+typedef struct assem_fixture {
+    memory *mem;
+    context *ctx;
+} assem_fixture;
+
+static void *test_assem_setup(const MunitParameter params[], void *fixture) {
+    assem_fixture *f = calloc(1, sizeof(assem_fixture));
+    f->ctx = calloc(1, sizeof(context));
+    f->mem = memory_init(ASSEM_MAX_ADDRESS);
+
+    context *c = f->ctx;
+
+    c->data_start = f->mem->data;
+    c->data = f->mem->data;
+    c->symbols = table_init();
+    c->line = 0;
+
+    return (void *)f;
+}
+
+static void test_assem_tear_down(void *fixture) {
+    assem_fixture *f = (assem_fixture *)fixture;
+    memory_free(f->mem);
+    table_free(f->ctx->symbols);
+    free(f->ctx);
+}
+
+static void assert_assem_equiv(context *c, char *line, size_t count,
+                               uint8_t *assem) {
+    char *prog = strdup(line);
+    uint8_t *offset = c->data;
+    bool success = tokenize(c, prog, 1);
+    munit_assert_true(success);
+    munit_assert_ptr_equal(c->data, offset + count);
+
+    for (int i = 0; i < count; i++) {
+        munit_assert_uint8(offset[i], ==, assem[i]);
+    }
+
+    free(prog);
+}
+
+static MunitResult test_assem_empty_string(const MunitParameter params[],
+                                           void *fixture) {
+    memory *m = build_image("", "");
+
+    for (size_t i = 0; i < m->size; i++) {
+        munit_assert_uint8(m->data[i], ==, 0);
+    }
+
+    memory_free(m);
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_empty_string(const MunitParameter params[],
+                                              void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    bool success = tokenize(c, "", 0);
+    munit_assert_true(success);
+    munit_assert_ptr_equal(c->data, c->data_start);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_org(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+    memory *m = ((assem_fixture *)fixture)->mem;
+
+    char *prog;
+    bool success;
+
+    prog = strdup("#org 0001");
+    success = tokenize(c, prog, 0);
+    munit_assert_true(success);
+
+    munit_assert_ptr_equal(c->data, c->data_start + 0x0001);
+
+    free(prog);
+    prog = strdup("#org 1000");
+    success = tokenize(c, prog, 1);
+    munit_assert_true(success);
+
+    munit_assert_ptr_equal(c->data, c->data_start + 0x1000);
+
+    free(prog);
+    prog = strdup("#org 00FF");
+    success = tokenize(c, prog, 2);
+    munit_assert_true(success);
+
+    munit_assert_ptr_equal(c->data, c->data_start + 0x00FF);
+
+    free(prog);
+
+    for (size_t i = 0; i < m->size; i++) {
+        munit_assert_uint8(c->data_start[i], ==, 0);
+    }
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_data(const MunitParameter params[],
+                                      void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    char *prog;
+    bool success;
+
+    prog = strdup("#data 0123 4567 89AB CDEF");
+    success = tokenize(c, prog, 0);
+    munit_assert_true(success);
+
+    munit_assert_ptr_equal(c->data, c->data_start + 16);
+
+    free(prog);
+    prog = strdup("#data FEDC BA98 7654 3210");
+    success = tokenize(c, prog, 1);
+    munit_assert_true(success);
+
+    munit_assert_ptr_equal(c->data, c->data_start + 32);
+
+    free(prog);
+
+    uint8_t expected[32] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                            11, 12, 13, 14, 15, 15, 14, 13, 12, 11, 10,
+                            9,  8,  7,  6,  5,  4,  3,  2,  1,  0};
+
+    for (size_t i = 0; i < 32; i++) {
+        munit_assert_uint8(c->data_start[i], ==, expected[i]);
+    }
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_comment(const MunitParameter params[],
+                                         void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    char *prog;
+    bool success;
+
+    prog = strdup("(this is a comment)");
+    success = tokenize(c, prog, 0);
+    munit_assert_true(success);
+
+    munit_assert_ptr_equal(c->data, c->data_start);
+
+    free(prog);
+    prog = strdup("NOP");
+    success = tokenize(c, prog, 1);
+    munit_assert_true(success);
+
+    free(prog);
+    prog = strdup("(((((()");
+    success = tokenize(c, prog, 2);
+    munit_assert_true(success);
+
+    munit_assert_ptr_equal(c->data, c->data_start + 1);
+
+    free(prog);
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_label(const MunitParameter params[],
+                                       void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    char *prog;
+    bool success;
+    symbol *s;
+
+    prog = strdup("A:");
+    success = tokenize(c, prog, 0);
+    munit_assert_true(success);
+
+    s = table_symbol_lookup(c->symbols, "A");
+
+    munit_assert_ptr_not_null(s);
+    munit_assert_string_equal(s->label, "A");
+    munit_assert_long(s->address, ==, 0);
+    munit_assert_ptr_equal(c->data, c->data_start);
+
+    free(prog);
+    prog = strdup("NOP");
+    success = tokenize(c, prog, 1);
+    munit_assert_true(success);
+
+    free(prog);
+    prog = strdup("ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz:");
+    success = tokenize(c, prog, 2);
+    munit_assert_true(success);
+
+    s = table_symbol_lookup(
+        c->symbols, "ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
+
+    munit_assert_ptr_not_null(s);
+    munit_assert_string_equal(
+        s->label, "ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
+    munit_assert_long(s->address, ==, 1);
+    munit_assert_ptr_equal(c->data, c->data_start + 1);
+
+    free(prog);
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_nop(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    uint8_t assem[] = {NOP};
+
+    assert_assem_equiv(c, "NOP", 1, assem);
+    assert_assem_equiv(c, "NOP", 1, assem);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_inc(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "INC \%a", 2, (uint8_t[]){INC, REGISTER_A});
+
+    assert_assem_equiv(c, "INC \%pc", 2, (uint8_t[]){INC, REGISTER_PC});
+
+    assert_assem_equiv(c, "INC \%sp", 2, (uint8_t[]){INC, REGISTER_SP});
+
+    assert_assem_equiv(c, "INC \%iv", 2, (uint8_t[]){INC, REGISTER_IV});
+
+    assert_assem_equiv(c, "INC \%ix", 2, (uint8_t[]){INC, REGISTER_IX});
+
+    assert_assem_equiv(c, "INC \%ta", 2, (uint8_t[]){INC, REGISTER_TA});
+
+    assert_assem_equiv(c, "INC @ABCD", 6,
+                       (uint8_t[]){INC, REGISTER_MD, 0xA, 0xB, 0xC, 0xD});
+
+    assert_assem_equiv(c, "INC *FEDC", 6,
+                       (uint8_t[]){INC, REGISTER_MX, 0xF, 0xE, 0xD, 0xC});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_dec(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "DEC \%a", 2, (uint8_t[]){DEC, REGISTER_A});
+
+    assert_assem_equiv(c, "DEC \%pc", 2, (uint8_t[]){DEC, REGISTER_PC});
+
+    assert_assem_equiv(c, "DEC @ABCD", 6,
+                       (uint8_t[]){DEC, REGISTER_MD, 0xA, 0xB, 0xC, 0xD});
+
+    assert_assem_equiv(c, "DEC *FEDC", 6,
+                       (uint8_t[]){DEC, REGISTER_MX, 0xF, 0xE, 0xD, 0xC});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_add(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "ADD \%b \%a", 3,
+                       (uint8_t[]){ADD, REGISTER_B, REGISTER_A});
+
+    assert_assem_equiv(c, "ADD 15 \%a", 4,
+                       (uint8_t[]){ADD, REGISTER_CV, REGISTER_A, 15});
+
+    assert_assem_equiv(
+        c, "ADD 0xFEDC \%pc", 7,
+        (uint8_t[]){ADD, REGISTER_CV, REGISTER_PC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(
+        c, "ADD 10 @FACE", 8,
+        (uint8_t[]){ADD, REGISTER_CV, REGISTER_MD, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(
+        c, "ADD 10 *FACE", 8,
+        (uint8_t[]){ADD, REGISTER_CV, REGISTER_MX, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(c, "ADD @ABCD @FE35", 11,
+                       (uint8_t[]){ADD, REGISTER_MD, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "ADD @ABCD *FE35", 11,
+                       (uint8_t[]){ADD, REGISTER_MD, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "ADD *ABCD @FE35", 11,
+                       (uint8_t[]){ADD, REGISTER_MX, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "ADD *ABCD *FE35", 11,
+                       (uint8_t[]){ADD, REGISTER_MX, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_sub(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "SUB \%b \%a", 3,
+                       (uint8_t[]){SUB, REGISTER_B, REGISTER_A});
+
+    assert_assem_equiv(c, "SUB 15 \%a", 4,
+                       (uint8_t[]){SUB, REGISTER_CV, REGISTER_A, 15});
+
+    assert_assem_equiv(
+        c, "SUB 0xFEDC \%pc", 7,
+        (uint8_t[]){SUB, REGISTER_CV, REGISTER_PC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(
+        c, "SUB 10 @FACE", 8,
+        (uint8_t[]){SUB, REGISTER_CV, REGISTER_MD, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(
+        c, "SUB 10 *FACE", 8,
+        (uint8_t[]){SUB, REGISTER_CV, REGISTER_MX, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(c, "SUB @ABCD @FE35", 11,
+                       (uint8_t[]){SUB, REGISTER_MD, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "SUB @ABCD *FE35", 11,
+                       (uint8_t[]){SUB, REGISTER_MD, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "SUB *ABCD @FE35", 11,
+                       (uint8_t[]){SUB, REGISTER_MX, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "SUB *ABCD *FE35", 11,
+                       (uint8_t[]){SUB, REGISTER_MX, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_rlc(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "RLC \%a", 2, (uint8_t[]){RLC, REGISTER_A});
+
+    // TODO: Is this a legal CPU instruction?
+    assert_assem_equiv(c, "RLC \%pc", 2, (uint8_t[]){RLC, REGISTER_PC});
+
+    assert_assem_equiv(c, "RLC @ABCD", 6,
+                       (uint8_t[]){RLC, REGISTER_MD, 0xA, 0xB, 0xC, 0xD});
+
+    assert_assem_equiv(c, "RLC *FEDC", 6,
+                       (uint8_t[]){RLC, REGISTER_MX, 0xF, 0xE, 0xD, 0xC});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_rrc(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "RRC \%a", 2, (uint8_t[]){RRC, REGISTER_A});
+
+    // TODO: Is this a legal CPU instruction?
+    assert_assem_equiv(c, "RRC \%pc", 2, (uint8_t[]){RRC, REGISTER_PC});
+
+    assert_assem_equiv(c, "RRC @ABCD", 6,
+                       (uint8_t[]){RRC, REGISTER_MD, 0xA, 0xB, 0xC, 0xD});
+
+    assert_assem_equiv(c, "RRC *FEDC", 6,
+                       (uint8_t[]){RRC, REGISTER_MX, 0xF, 0xE, 0xD, 0xC});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_and(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "AND \%b \%a", 3,
+                       (uint8_t[]){AND, REGISTER_B, REGISTER_A});
+
+    assert_assem_equiv(c, "AND 15 \%a", 4,
+                       (uint8_t[]){AND, REGISTER_CV, REGISTER_A, 15});
+
+    assert_assem_equiv(
+        c, "AND 0xFEDC \%pc", 7,
+        (uint8_t[]){AND, REGISTER_CV, REGISTER_PC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(
+        c, "AND 10 @FACE", 8,
+        (uint8_t[]){AND, REGISTER_CV, REGISTER_MD, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(
+        c, "AND 10 *FACE", 8,
+        (uint8_t[]){AND, REGISTER_CV, REGISTER_MX, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(c, "AND @ABCD @FE35", 11,
+                       (uint8_t[]){AND, REGISTER_MD, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "AND @ABCD *FE35", 11,
+                       (uint8_t[]){AND, REGISTER_MD, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "AND *ABCD @FE35", 11,
+                       (uint8_t[]){AND, REGISTER_MX, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "AND *ABCD *FE35", 11,
+                       (uint8_t[]){AND, REGISTER_MX, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_or(const MunitParameter params[],
+                                    void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "OR \%b \%a", 3,
+                       (uint8_t[]){OR, REGISTER_B, REGISTER_A});
+
+    assert_assem_equiv(c, "OR 15 \%a", 4,
+                       (uint8_t[]){OR, REGISTER_CV, REGISTER_A, 15});
+
+    assert_assem_equiv(
+        c, "OR 0xFEDC \%pc", 7,
+        (uint8_t[]){OR, REGISTER_CV, REGISTER_PC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(
+        c, "OR 10 @FACE", 8,
+        (uint8_t[]){OR, REGISTER_CV, REGISTER_MD, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(
+        c, "OR 10 *FACE", 8,
+        (uint8_t[]){OR, REGISTER_CV, REGISTER_MX, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(c, "OR @ABCD @FE35", 11,
+                       (uint8_t[]){OR, REGISTER_MD, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "OR @ABCD *FE35", 11,
+                       (uint8_t[]){OR, REGISTER_MD, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "OR *ABCD @FE35", 11,
+                       (uint8_t[]){OR, REGISTER_MX, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "OR *ABCD *FE35", 11,
+                       (uint8_t[]){OR, REGISTER_MX, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_xor(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "XOR \%b \%a", 3,
+                       (uint8_t[]){XOR, REGISTER_B, REGISTER_A});
+
+    assert_assem_equiv(c, "XOR 15 \%a", 4,
+                       (uint8_t[]){XOR, REGISTER_CV, REGISTER_A, 15});
+
+    assert_assem_equiv(
+        c, "XOR 0xFEDC \%pc", 7,
+        (uint8_t[]){XOR, REGISTER_CV, REGISTER_PC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(
+        c, "XOR 10 @FACE", 8,
+        (uint8_t[]){XOR, REGISTER_CV, REGISTER_MD, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(
+        c, "XOR 10 *FACE", 8,
+        (uint8_t[]){XOR, REGISTER_CV, REGISTER_MX, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(c, "XOR @ABCD @FE35", 11,
+                       (uint8_t[]){XOR, REGISTER_MD, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "XOR @ABCD *FE35", 11,
+                       (uint8_t[]){XOR, REGISTER_MD, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "XOR *ABCD @FE35", 11,
+                       (uint8_t[]){XOR, REGISTER_MX, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "XOR *ABCD *FE35", 11,
+                       (uint8_t[]){XOR, REGISTER_MX, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_cmp(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "CMP \%b \%a", 3,
+                       (uint8_t[]){CMP, REGISTER_B, REGISTER_A});
+
+    assert_assem_equiv(c, "CMP 15 \%a", 4,
+                       (uint8_t[]){CMP, REGISTER_CV, REGISTER_A, 15});
+
+    assert_assem_equiv(
+        c, "CMP 0xFEDC \%pc", 7,
+        (uint8_t[]){CMP, REGISTER_CV, REGISTER_PC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(
+        c, "CMP 10 @FACE", 8,
+        (uint8_t[]){CMP, REGISTER_CV, REGISTER_MD, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(
+        c, "CMP 10 *FACE", 8,
+        (uint8_t[]){CMP, REGISTER_CV, REGISTER_MX, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(c, "CMP @ABCD @FE35", 11,
+                       (uint8_t[]){CMP, REGISTER_MD, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "CMP @ABCD *FE35", 11,
+                       (uint8_t[]){CMP, REGISTER_MD, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "CMP *ABCD @FE35", 11,
+                       (uint8_t[]){CMP, REGISTER_MX, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "CMP *ABCD *FE35", 11,
+                       (uint8_t[]){CMP, REGISTER_MX, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_psh(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "PSH \%a", 2, (uint8_t[]){PSH, REGISTER_A});
+
+    assert_assem_equiv(c, "PSH \%pc", 2, (uint8_t[]){PSH, REGISTER_PC});
+
+    assert_assem_equiv(c, "PSH 10", 3, (uint8_t[]){PSH, REGISTER_CV, 0xA});
+
+    assert_assem_equiv(c, "PSH @ABCD", 6,
+                       (uint8_t[]){PSH, REGISTER_MD, 0xA, 0xB, 0xC, 0xD});
+
+    assert_assem_equiv(c, "PSH *FEDC", 6,
+                       (uint8_t[]){PSH, REGISTER_MX, 0xF, 0xE, 0xD, 0xC});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_pop(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "POP \%a", 2, (uint8_t[]){POP, REGISTER_A});
+
+    assert_assem_equiv(c, "POP \%pc", 2, (uint8_t[]){POP, REGISTER_PC});
+
+    assert_assem_equiv(c, "POP @ABCD", 6,
+                       (uint8_t[]){POP, REGISTER_MD, 0xA, 0xB, 0xC, 0xD});
+
+    assert_assem_equiv(c, "POP *FEDC", 6,
+                       (uint8_t[]){POP, REGISTER_MX, 0xF, 0xE, 0xD, 0xC});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_jmp(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "JMP N=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x0, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP N=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x8, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP Z=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x1, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP Z=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x9, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP C=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x2, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP C=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0xA, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP O=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x3, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP O=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0xB, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP I=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x4, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP I=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0xC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP H=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x5, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP H=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0xD, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP 0=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x6, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP 0=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0xE, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP 1=0 @FEDC", 6,
+                       (uint8_t[]){JMP, 0x7, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP 1=1 @FEDC", 6,
+                       (uint8_t[]){JMP, 0xF, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JMP 1=1 *1234", 6,
+                       (uint8_t[]){JMP, 0xF, 0x1, 0x2, 0x3, 0x4});
+
+    char *prog = strdup("LOOP:");
+    bool success = tokenize(c, prog, 1);
+    munit_assert_true(success);
+    free(prog);
+
+    assert_assem_equiv(c, "JMP 1=1 .LOOP", 6,
+                       (uint8_t[]){JMP, 0xF, 0x0, 0x0, 0x0, 0x0});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_jsr(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "JSR N=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x0, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR N=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x8, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR Z=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x1, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR Z=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x9, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR C=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x2, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR C=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0xA, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR O=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x3, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR O=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0xB, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR I=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x4, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR I=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0xC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR H=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x5, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR H=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0xD, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR 0=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x6, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR 0=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0xE, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR 1=0 @FEDC", 6,
+                       (uint8_t[]){JSR, 0x7, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR 1=1 @FEDC", 6,
+                       (uint8_t[]){JSR, 0xF, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(c, "JSR 1=1 *1234", 6,
+                       (uint8_t[]){JSR, 0xF, 0x1, 0x2, 0x3, 0x4});
+
+    char *prog = strdup("LOOP:");
+    bool success = tokenize(c, prog, 1);
+    munit_assert_true(success);
+    free(prog);
+
+    assert_assem_equiv(c, "JSR 1=1 .LOOP", 6,
+                       (uint8_t[]){JSR, 0xF, 0x0, 0x0, 0x0, 0x0});
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_tokenize_mov(const MunitParameter params[],
+                                     void *fixture) {
+    context *c = ((assem_fixture *)fixture)->ctx;
+
+    assert_assem_equiv(c, "MOV \%b \%a", 3,
+                       (uint8_t[]){MOV, REGISTER_B, REGISTER_A});
+
+    assert_assem_equiv(c, "MOV 15 \%a", 4,
+                       (uint8_t[]){MOV, REGISTER_CV, REGISTER_A, 15});
+
+    assert_assem_equiv(c, "MOV \%pc \%sp", 3,
+                       (uint8_t[]){MOV, REGISTER_PC, REGISTER_SP});
+
+    assert_assem_equiv(c, "MOV \%pc \%iv", 3,
+                       (uint8_t[]){MOV, REGISTER_PC, REGISTER_IV});
+
+    assert_assem_equiv(c, "MOV \%pc \%ix", 3,
+                       (uint8_t[]){MOV, REGISTER_PC, REGISTER_IX});
+
+    assert_assem_equiv(c, "MOV \%pc \%ta", 3,
+                       (uint8_t[]){MOV, REGISTER_PC, REGISTER_TA});
+
+    assert_assem_equiv(
+        c, "MOV 0xFEDC \%pc", 7,
+        (uint8_t[]){MOV, REGISTER_CV, REGISTER_PC, 0xF, 0xE, 0xD, 0xC});
+
+    assert_assem_equiv(
+        c, "MOV 10 @FACE", 8,
+        (uint8_t[]){MOV, REGISTER_CV, REGISTER_MD, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(
+        c, "MOV 10 *FACE", 8,
+        (uint8_t[]){MOV, REGISTER_CV, REGISTER_MX, 0xA, 0xF, 0xA, 0xC, 0xE});
+
+    assert_assem_equiv(c, "MOV @ABCD @FE35", 11,
+                       (uint8_t[]){MOV, REGISTER_MD, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "MOV @ABCD *FE35", 11,
+                       (uint8_t[]){MOV, REGISTER_MD, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "MOV *ABCD @FE35", 11,
+                       (uint8_t[]){MOV, REGISTER_MX, REGISTER_MD, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    assert_assem_equiv(c, "MOV *ABCD *FE35", 11,
+                       (uint8_t[]){MOV, REGISTER_MX, REGISTER_MX, 0xA, 0xB, 0xC,
+                                   0xD, 0xF, 0xE, 0x3, 0x5});
+
+    return MUNIT_OK;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+static MunitTest assem_assem_tests[] = {
+    {(char *)"trivial case assembles correctly", test_assem_empty_string, NULL,
+     NULL, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"empty string tokenizes correctly", test_tokenize_empty_string,
+     test_assem_setup, test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"org directives tokenize correctly", test_tokenize_org,
+     test_assem_setup, test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"data directives tokenize correctly", test_tokenize_data,
+     test_assem_setup, test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"comments tokenize correctly", test_tokenize_comment,
+     test_assem_setup, test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"labels tokenize correctly", test_tokenize_label, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"NOP tokenizes correctly", test_tokenize_nop, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"INC tokenizes correctly", test_tokenize_inc, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"DEC tokenizes correctly", test_tokenize_dec, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"ADD tokenizes correctly", test_tokenize_add, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"SUB tokenizes correctly", test_tokenize_sub, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"RLC tokenizes correctly", test_tokenize_rlc, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"RRC tokenizes correctly", test_tokenize_rrc, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"AND tokenizes correctly", test_tokenize_and, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)" OR tokenizes correctly", test_tokenize_or, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"XOR tokenizes correctly", test_tokenize_xor, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"CMP tokenizes correctly", test_tokenize_cmp, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"PSH tokenizes correctly", test_tokenize_psh, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"POP tokenizes correctly", test_tokenize_pop, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"JMP tokenizes correctly", test_tokenize_jmp, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"JSR tokenizes correctly", test_tokenize_jsr, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"MOV tokenizes correctly", test_tokenize_mov, test_assem_setup,
+     test_assem_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+#pragma GCC diagnostic pop

--- a/src/test/test_assem.h
+++ b/src/test/test_assem.h
@@ -1,0 +1,44 @@
+#ifndef BBB_ASSEM_PVT_H
+#define BBB_ASSEM_PVT_H
+
+#include "../assem/table.h"
+#include "../machine/memory.h"
+
+typedef enum ParseState {
+    PARSE_OPER,
+    PARSE_TEST,
+    PARSE_ADDR,
+    PARSE_DEST,
+    PARSE_OPER_SRC,
+    PARSE_PUSH_SRC,
+    PARSE_ORG_ADDR,
+    PARSE_DATA,
+    PARSE_DONE,
+    PARSE_ERROR = 0xFF
+} ParseState;
+
+typedef enum { META_ORG, META_DATA, META_INCLUDE, META_ERROR } MetaDirective;
+
+typedef struct context {
+    uint8_t *data_start;
+    uint8_t *data;
+    table *symbols;
+    uint32_t line;
+} context;
+
+bool tokenize(context *ctx, char *line, uint16_t num);
+static inline ParseState parse_directive(context *ctx, char *token);
+static inline ParseState parse_opcode(context *ctx, char *token);
+static inline ParseState parse_condition(context *ctx, char *token);
+static inline ParseState parse_src(context *ctx, char *token, uint16_t *ext,
+                                   char **label);
+static inline ParseState parse_dest(context *ctx, char *token, uint16_t *ext,
+                                    char **label);
+static inline bool parse_register(context *ctx, char *token, uint8_t *reg);
+static inline bool parse_addr(context *ctx, char *token, uint16_t *addr,
+                              char **label);
+static inline bool parse_hex(char *token, uint8_t length, uint16_t *result);
+static inline bool parse_int(char *token, uint16_t *result);
+static inline bool parse_label(char *token);
+
+#endif

--- a/src/test/test_build.c
+++ b/src/test/test_build.c
@@ -1,0 +1,39 @@
+#include <memory.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../assem/assem.h"
+#include "../munit/munit.h"
+
+#define ASSEM_MAX_ADDRESS (64 * 1024)
+
+// static void *test_memory_setup(const MunitParameter params[], void *fixture)
+// {
+//     memory *m = memory_init(ASSEM_MAX_ADDRESS);
+//     return (void *)m;
+// }
+
+// static void test_memory_tear_down(void *fixture) {
+//     memory *m = (memory *)fixture;
+//     memory_free(m);
+// }
+
+static MunitResult test_build_image_trivial_case(const MunitParameter params[],
+                                                 void *fixture) {
+    memory *m = build_image("", "");
+
+    for (size_t i = 0; i < m->size; i++) {
+        munit_assert_uint8(m->data[i], ==, 0);
+    }
+
+    memory_free(m);
+    return MUNIT_OK;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+static MunitTest assem_build_tests[] = {
+    {(char *)"trivial case builds correctly", test_build_image_trivial_case,
+     NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+    {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+#pragma GCC diagnostic pop

--- a/src/test/test_memory.c
+++ b/src/test/test_memory.c
@@ -63,9 +63,10 @@ test_memory_out_of_bounds_read_write(const MunitParameter params[],
     memory *m = (memory *)fixture;
 
     for (int i = 0; i < 1024; i++) {
-        size_t addr = munit_rand_int_range(0, MAX_ADDRESS);
+        size_t addr = munit_rand_int_range(1, MAX_ADDRESS);
         uint8_t write = munit_rand_int_range(0, 255);
 
+        munit_assert_ulong(m->size, <, MAX_ADDRESS + addr);
         memory_write(m, MAX_ADDRESS + addr, write);
 
         uint8_t read = memory_read(m, MAX_ADDRESS + addr);

--- a/src/test/test_memory.c
+++ b/src/test/test_memory.c
@@ -23,7 +23,7 @@ static MunitResult test_memory_read_write(const MunitParameter params[],
     memory *m = (memory *)fixture;
 
     for (int i = 0; i < 1024; i++) {
-        size_t addr = munit_rand_int_range(0, MAX_ADDRESS);
+        size_t addr = munit_rand_int_range(0, MAX_ADDRESS - 1);
         uint8_t write = munit_rand_int_range(0, 255);
 
         memory_write(m, addr, write);
@@ -38,13 +38,13 @@ static MunitResult test_memory_read_write(const MunitParameter params[],
 static MunitResult test_memory_read_write_indexed(const MunitParameter params[],
                                                   void *fixture) {
     memory *m = (memory *)fixture;
+    uint8_t *index = m->data;
 
     for (int i = 0; i < 1024; i++) {
-        uint8_t *index = m->data;
-        size_t s = munit_rand_int_range(0, MAX_ADDRESS);
+        size_t s = munit_rand_int_range(0, MAX_ADDRESS - 1);
 
         for (int j = 0; j < 1024; j++) {
-            size_t offset = munit_rand_int_range(0, MAX_ADDRESS - s);
+            size_t offset = munit_rand_int_range(0, MAX_ADDRESS - 1 - s);
             uint8_t write = munit_rand_int_range(0, 255);
 
             memory_write_indexed(m, index + s, offset, write);
@@ -63,13 +63,13 @@ test_memory_out_of_bounds_read_write(const MunitParameter params[],
     memory *m = (memory *)fixture;
 
     for (int i = 0; i < 1024; i++) {
-        size_t addr = munit_rand_int_range(1, MAX_ADDRESS);
+        size_t addr = munit_rand_int_range(MAX_ADDRESS, MAX_ADDRESS * 2);
         uint8_t write = munit_rand_int_range(0, 255);
 
-        munit_assert_ulong(m->size, <, MAX_ADDRESS + addr);
-        memory_write(m, MAX_ADDRESS + addr, write);
+        munit_assert_ulong(m->size, <=, addr);
+        memory_write(m, addr, write);
 
-        uint8_t read = memory_read(m, MAX_ADDRESS + addr);
+        uint8_t read = memory_read(m, addr);
         munit_assert_uint8(0, ==, read);
     }
 


### PR DESCRIPTION
- Fixes bounds errors in `memory.c`
- Adds `inspect` command to `bbb`
- Adds thorough tests for assembler
- Adds private headers for `assem.c` to test directory