### PR TITLE
Add CPU execution tests

### DIFF
--- a/src/machine/cpu.c
+++ b/src/machine/cpu.c
@@ -492,10 +492,10 @@ extern inline void machine_instr_execute(machine *m) {
         if ((m->flags & (1 << (m->dst & 7))) ==
             (((m->dst & 8) >> 3) << (m->dst & 7))) {
             uint16_t pc = m->pc - m->memory->data;
-            *(m->sp)++ = pc & 0xF;
-            *(m->sp)++ = (pc >> 4) & 0xF;
-            *(m->sp)++ = (pc >> 8) & 0xF;
             *(m->sp)++ = (pc >> 12) & 0xF;
+            *(m->sp)++ = (pc >> 8) & 0xF;
+            *(m->sp)++ = (pc >> 4) & 0xF;
+            *(m->sp)++ = (pc >> 0) & 0xF;
             m->pc = m->memory->data + m->dst_ext;
         }
         break;

--- a/src/machine/cpu.c
+++ b/src/machine/cpu.c
@@ -11,7 +11,7 @@
     (*(x) << 12 | *((x) + 1) << 8 | *((x) + 2) << 4 | *((x) + 3));             \
     (x) += 4
 
-#define SET_HALT(x) ((x) |= 0x20)
+#define SET_HALT(x) ((x) |= FLAG_HALT)
 #define SET_CMP(x, lhs, rhs)                                                   \
     ((x) = ((x) & 0xFC) | (((lhs) == (rhs)) << 1) | ((lhs) > (rhs)))
 #define SET_ZN(x, val)                                                         \
@@ -46,7 +46,8 @@ static inline uint16_t machine_get_value(machine *m, Register src,
     case REGISTER_TA:
         return m->ta - m->memory->data;
     case REGISTER_S0:
-        return m->flags & 0x0F;
+        return m->flags &
+               (FLAG_OVERFLOW | FLAG_CARRY | FLAG_ZERO | FLAG_NEGATIVE);
     case REGISTER_S1:
         return m->flags >> 4;
     default:
@@ -58,10 +59,10 @@ static inline void machine_set_value(machine *m, Register dst, uint16_t dst_ext,
                                      uint16_t value) {
     switch (dst) {
     case REGISTER_CV:
-        m->flags |= 0x20;
+        m->flags |= FLAG_HALT;
         break;
     case REGISTER_MD:
-        memory_write(m->memory, dst_ext, value);
+        memory_write(m->memory, dst_ext, value & 0xF);
         break;
     case REGISTER_MX:
         memory_write_indexed(m->memory, m->ix, dst_ext, value & 0xF);
@@ -82,10 +83,11 @@ static inline void machine_set_value(machine *m, Register dst, uint16_t dst_ext,
         m->ta = (m->memory->data + value);
         break;
     case REGISTER_S0:
-        m->flags = (m->flags & 0xF0) | (value & 0x0F);
+        m->flags = (m->flags & MASK_REGISTER_S1) | (value & MASK_REGISTER_S0);
         break;
     case REGISTER_S1:
-        m->flags = (m->flags & 0x0F) | 0x80 | ((value & 0x03) << 4);
+        m->flags = (m->flags & MASK_REGISTER_S0) | FLAG_TRUE |
+                   ((value << 4) & (FLAG_HALT | FLAG_INTERRUPT));
         break;
     default:
         m->registers[dst] = value & 0xF;
@@ -120,7 +122,7 @@ void machine_halt(machine *m);
 void machine_reset(machine *m) {
     m->status = STATE_HALT;
     m->pc = m->sp = m->iv = m->ix = m->ta = m->memory->data;
-    m->flags = 0x80;
+    m->flags = FLAG_TRUE;
 
     for (uint8_t i = 0; i < CPU_REGISTER_COUNT; i++) {
         m->registers[i] = 0;
@@ -129,7 +131,7 @@ void machine_reset(machine *m) {
 
 void machine_run(machine *m) {
     machine_call_update(m);
-    while (!(m->flags & 0x20)) {
+    while (!(m->flags & FLAG_HALT)) {
         machine_instr_fetch(m);
         machine_instr_decode(m);
         machine_instr_execute(m);
@@ -152,7 +154,7 @@ void machine_call_teardown(machine *m) {
 }
 
 inline void machine_interrupt_check(machine *m) {
-    if (!(m->flags & 0x10) || m->int_mask) {
+    if (!(m->flags & FLAG_INTERRUPT) || m->int_mask) {
         return;
     } else {
         m->int_mask = true;
@@ -278,6 +280,12 @@ extern inline void machine_instr_decode(machine *m) {
 }
 
 extern inline void machine_instr_execute(machine *m) {
+    // There are cases where the instruction decode step will set the halt flag
+    // and we want execution to stop completely
+    if (m->flags & FLAG_HALT) {
+        return;
+    }
+
     switch (m->instr) {
     case NOP: {
         break;
@@ -285,12 +293,22 @@ extern inline void machine_instr_execute(machine *m) {
     case INC: {
         uint16_t value = machine_get_value(m, m->dst, m->dst_ext) + 1;
         machine_set_value(m, m->dst, m->dst_ext, value);
+
+        if (m->dst < REGISTER_PC || m->dst > REGISTER_CV) {
+            value |= (value & 0x8) << 13;
+        }
+
         SET_ZN(m->flags, value);
         break;
     }
     case DEC: {
         uint16_t value = machine_get_value(m, m->dst, m->dst_ext) - 1;
         machine_set_value(m, m->dst, m->dst_ext, value);
+
+        if (m->dst < REGISTER_PC || m->dst > REGISTER_CV) {
+            value |= (value & 0x8) << 13;
+        }
+
         SET_ZN(m->flags, value);
         break;
     }
@@ -311,18 +329,40 @@ extern inline void machine_instr_execute(machine *m) {
     }
     case RLC: {
         uint16_t value = machine_get_value(m, m->dst, m->dst_ext);
-        uint8_t flags = m->flags;
-        m->flags = (value & 0xA000) | (flags & 0xFB);
-        value = (value << 1) | ((flags & 0x4) >> 2);
+        uint8_t carry = m->flags & FLAG_CARRY;
+        uint8_t flags = m->flags & ~FLAG_CARRY;
+        uint16_t mask;
+
+        if (m->dst < REGISTER_PC || m->dst > REGISTER_CV) {
+            m->flags = flags | ((value & 0x8) >> 1);
+            mask = 0x000F;
+        } else {
+            m->flags = flags | ((value & 0x8000) >> 13);
+            mask = 0xFFFF;
+        }
+
+        value = ((value << 1) | (carry >> 2)) & mask;
         machine_set_value(m, m->dst, m->dst_ext, value);
         SET_ZN(m->flags, value);
         break;
     }
     case RRC: {
         uint16_t value = machine_get_value(m, m->dst, m->dst_ext);
-        uint8_t flags = m->flags;
-        m->flags = (value & 0x1) | (flags & 0xFB);
-        value = (value >> 1) | ((flags & 0x4) << 13);
+        uint16_t carry = m->flags & FLAG_CARRY;
+        uint8_t flags = m->flags & ~FLAG_CARRY;
+        uint16_t mask;
+
+        m->flags = flags | ((value & 0x1) << 2);
+
+        if (m->dst < REGISTER_PC || m->dst > REGISTER_CV) {
+            mask = 0x000F;
+            carry = carry << 1;
+        } else {
+            mask = 0xFFFF;
+            carry <<= 13;
+        }
+
+        value = ((value >> 1) | carry) & mask;
         machine_set_value(m, m->dst, m->dst_ext, value);
         SET_ZN(m->flags, value);
         break;
@@ -389,25 +429,40 @@ extern inline void machine_instr_execute(machine *m) {
     }
     case PSH: {
         // TODO: Push 4 values if the source is 16 bit?
-        *(m->sp)++ = machine_get_value(m, m->src, m->src_ext) & 0xF;
+        uint16_t value = machine_get_value(m, m->src, m->src_ext);
+
+        if (m->src < REGISTER_PC || m->src > REGISTER_TA) {
+            *(m->sp)++ = value & 0xF;
+        } else {
+            *(m->sp)++ = (value >> 12) & 0xF;
+            *(m->sp)++ = (value >> 8) & 0xF;
+            *(m->sp)++ = (value >> 4) & 0xF;
+            *(m->sp)++ = (value >> 0) & 0xF;
+        }
+
         break;
     }
     case POP: {
-        uint16_t value = *(m->sp)-- & 0xF;
-        // TODO: Pop 4 values if the destination is 16 bit?
-        if (m->dst >= REGISTER_PC) {
-            if (m->int_mask && ~m->flags & 0x10) {
-                // The interrupt mask has been cleared by software
-                // so we can unmask the interrupt
-                m->int_mask = false;
-            }
-            // Moving a 4-bit value into a 16-bit register.
-            // Combine the masked src and dst values
-            uint16_t dst = machine_get_value(m, m->dst, m->dst_ext);
-            machine_set_value(m, m->dst, m->dst_ext, (dst & 0xFFF0) | value);
+        uint16_t value;
+
+        if (m->dst < REGISTER_PC || m->dst > REGISTER_CV) {
+            value = *--(m->sp);
         } else {
-            machine_set_value(m, m->dst, m->dst_ext, value);
+            value = *--(m->sp);
+            value |= *--(m->sp) << 4;
+            value |= *--(m->sp) << 8;
+            value |= *--(m->sp) << 12;
         }
+
+        machine_set_value(m, m->dst, m->dst_ext, value);
+
+        if (m->dst == REGISTER_PC && m->int_mask &&
+            ~m->flags & FLAG_INTERRUPT) {
+            // The interrupt mask has been cleared by software
+            // so we can unmask the interrupt
+            m->int_mask = false;
+        }
+
         break;
     }
     case JMP: {

--- a/src/machine/cpu.h
+++ b/src/machine/cpu.h
@@ -57,7 +57,7 @@ typedef struct machine {
     // - The status registers S0 and S2 are stored as the high and low
     // nibbles of the flags byte.
     MachineState status;
-    uint8_t registers[CPU_REGISTER_COUNT]; // TODO: Find out why there are 8
+    uint8_t registers[CPU_REGISTER_COUNT];
     uint8_t flags;
 
     // The pc, sp, iv, ix, and ta registers are all pointers into memory.

--- a/src/machine/cpu.h
+++ b/src/machine/cpu.h
@@ -19,7 +19,7 @@ typedef enum {
     REGISTER_E,  // General purpose register E
     REGISTER_F,  // General purpose register F
     REGISTER_S0, // Status register 0 (O, C, Z, N)
-    REGISTER_S1, // Status register 1 (1, 0, H, I)
+    REGISTER_S1, // Status register 1 (T, F, H, I)
     REGISTER_PC, // Program counter
     REGISTER_SP, // Stack pointer
     REGISTER_IV, // Interrupt vector
@@ -48,6 +48,20 @@ typedef enum {
     JSR, // Jump to subroutine
     MOV  // Move the contents of <src> to <dst>
 } Opcode;
+
+typedef enum {
+    FLAG_NEGATIVE = 1 << 0,
+    FLAG_ZERO = 1 << 1,
+    FLAG_CARRY = 1 << 2,
+    FLAG_OVERFLOW = 1 << 3,
+    FLAG_INTERRUPT = 1 << 4,
+    FLAG_HALT = 1 << 5,
+    FLAG_FALSE = 1 << 6,
+    FLAG_TRUE = 1 << 7,
+} Flag;
+
+#define MASK_REGISTER_S0 0x0F
+#define MASK_REGISTER_S1 0xF0
 
 typedef struct machine {
     // - The machine status indicates whether it is running or halted.

--- a/src/test.c
+++ b/src/test.c
@@ -3,6 +3,7 @@
 #include "test/test_assem.c"
 #include "test/test_build.c"
 #include "test/test_cpu.c"
+#include "test/test_cpu_exec.c"
 #include "test/test_memory.c"
 #include "test/test_table.c"
 
@@ -16,6 +17,8 @@ MunitSuite suites[] = { // Comment here to force formatting
     {(char *)"machine/memory: ", machine_memory_tests, NULL, 1,
      MUNIT_SUITE_OPTION_NONE},
     {(char *)"machine/cpu: ", machine_cpu_tests, NULL, 1,
+     MUNIT_SUITE_OPTION_NONE},
+    {(char *)"machine/cpu_exec: ", machine_cpu_exec_tests, NULL, 1,
      MUNIT_SUITE_OPTION_NONE},
     {NULL, NULL, NULL, 0, MUNIT_SUITE_OPTION_NONE}};
 

--- a/src/test/test_cpu.c
+++ b/src/test/test_cpu.c
@@ -110,7 +110,7 @@ static MunitResult test_cpu_program_halt(const MunitParameter params[],
     machine_start(m);
     machine_run(m);
 
-    munit_assert_uint8(m->flags, ==, 0x20);
+    munit_assert_uint8(m->flags, ==, 0xA0);
     munit_assert_ptr_equal(m->pc, m->memory->data + 24);
     return MUNIT_OK;
 }

--- a/src/test/test_cpu.h
+++ b/src/test/test_cpu.h
@@ -1,0 +1,14 @@
+#ifndef BBB_TEST_CPU_H
+#define BBB_TEST_CPU_H
+
+#include "../machine/cpu.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundefined-inline"
+extern inline void machine_instr_fetch(machine *m);
+extern inline void machine_instr_decode(machine *m);
+extern inline void machine_instr_execute(machine *m);
+extern inline void machine_interrupt_check(machine *m);
+#pragma GCC diagnostic pop
+
+#endif

--- a/src/test/test_cpu_exec.c
+++ b/src/test/test_cpu_exec.c
@@ -2004,26 +2004,837 @@ static MunitResult test_cpu_exec_pop(const MunitParameter params[],
 static MunitResult test_cpu_exec_jmp(const MunitParameter params[],
                                      void *fixture) {
     machine *m = (machine *)fixture;
-    uint8_t program[] = {NOP};
-    memcpy(m->memory->data, program, 1);
+
+    uint8_t jmp_n[] = {JMP, 0x8, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_n, 6);
+    m->flags |= FLAG_NEGATIVE;
 
     machine_step(m);
 
-    munit_assert_uint8(m->flags, ==, 0x80);
-    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_NEGATIVE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags &= ~FLAG_NEGATIVE;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_nn[] = {JMP, 0x0, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_nn, 6);
+    m->flags &= ~FLAG_NEGATIVE;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags |= FLAG_NEGATIVE;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_NEGATIVE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_z[] = {JMP, 0x9, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_z, 6);
+    m->flags |= FLAG_ZERO;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_ZERO));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags &= ~FLAG_ZERO;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_nz[] = {JMP, 0x1, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_nz, 6);
+    m->flags &= ~FLAG_ZERO;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags |= FLAG_ZERO;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_ZERO));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_c[] = {JMP, 0xA, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_c, 6);
+    m->flags |= FLAG_CARRY;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_CARRY));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags &= ~FLAG_CARRY;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_nc[] = {JMP, 0x2, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_nc, 6);
+    m->flags &= ~FLAG_CARRY;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags |= FLAG_CARRY;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_CARRY));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_o[] = {JMP, 0xB, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_o, 6);
+    m->flags |= FLAG_OVERFLOW;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_OVERFLOW));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags &= ~FLAG_OVERFLOW;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_no[] = {JMP, 0x3, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_no, 6);
+    m->flags &= ~FLAG_OVERFLOW;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags |= FLAG_OVERFLOW;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_OVERFLOW));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_i[] = {JMP, 0xC, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_i, 6);
+    // m->flags |= FLAG_INTERRUPT;
+
+    // machine_step(m);
+
+    // munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_INTERRUPT));
+    // munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    // machine_reset(m);
+
+    m->flags &= ~FLAG_INTERRUPT;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_ni[] = {JMP, 0x4, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_ni, 6);
+    m->flags &= ~FLAG_INTERRUPT;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    // m->flags |= FLAG_INTERRUPT;
+
+    // machine_step(m);
+
+    // munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_INTERRUPT));
+    // munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    // machine_reset(m);
+
+    uint8_t jmp_h[] = {JMP, 0xD, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_h, 6);
+    // m->flags |= FLAG_HALT;
+
+    // machine_step(m);
+
+    // munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_HALT));
+    // munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    // machine_reset(m);
+
+    m->flags &= ~FLAG_HALT;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_nh[] = {JMP, 0x5, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_nh, 6);
+    m->flags &= ~FLAG_HALT;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    m->flags |= FLAG_HALT;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_HALT));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_f[] = {JMP, 0xE, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_f, 6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    uint8_t jmp_nf[] = {JMP, 0x6, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_nf, 6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    uint8_t jmp_t[] = {JMP, 0xF, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_t, 6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+
+    machine_reset(m);
+
+    uint8_t jmp_nt[] = {JMP, 0x7, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jmp_nt, 6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
     return MUNIT_OK;
 }
 
 static MunitResult test_cpu_exec_jsr(const MunitParameter params[],
                                      void *fixture) {
     machine *m = (machine *)fixture;
-    uint8_t program[] = {NOP};
-    memcpy(m->memory->data, program, 1);
+
+    uint8_t jsr_n[] = {JSR, 0x8, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_n, 6);
+    m->flags |= FLAG_NEGATIVE;
+    m->sp += 0xA000;
 
     machine_step(m);
 
-    munit_assert_uint8(m->flags, ==, 0x80);
-    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_NEGATIVE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags &= ~FLAG_NEGATIVE;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_nn[] = {JSR, 0x0, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_nn, 6);
+    m->flags &= ~FLAG_NEGATIVE;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags |= FLAG_NEGATIVE;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_NEGATIVE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_z[] = {JSR, 0x9, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_z, 6);
+    m->flags |= FLAG_ZERO;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_ZERO));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags &= ~FLAG_ZERO;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_nz[] = {JSR, 0x1, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_nz, 6);
+    m->flags &= ~FLAG_ZERO;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags |= FLAG_ZERO;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_ZERO));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_c[] = {JSR, 0xA, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_c, 6);
+    m->flags |= FLAG_CARRY;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_CARRY));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags &= ~FLAG_CARRY;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_nc[] = {JSR, 0x2, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_nc, 6);
+    m->flags &= ~FLAG_CARRY;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags |= FLAG_CARRY;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_CARRY));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_o[] = {JSR, 0xB, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_o, 6);
+    m->flags |= FLAG_OVERFLOW;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_OVERFLOW));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags &= ~FLAG_OVERFLOW;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_no[] = {JSR, 0x3, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_no, 6);
+    m->flags &= ~FLAG_OVERFLOW;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags |= FLAG_OVERFLOW;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_OVERFLOW));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_i[] = {JSR, 0xC, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_i, 6);
+    // m->flags |= FLAG_INTERRUPT;
+    // m->sp += 0xA000;
+
+    // machine_step(m);
+
+    // munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_INTERRUPT));
+    // munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    // munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    // munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    // machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags &= ~FLAG_INTERRUPT;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_ni[] = {JSR, 0x4, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_ni, 6);
+    m->flags &= ~FLAG_INTERRUPT;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    // m->memory->data[0xA003] = 0x0;
+    // m->flags |= FLAG_INTERRUPT;
+
+    // machine_step(m);
+
+    // munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_INTERRUPT));
+    // munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    // munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    // munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    // machine_reset(m);
+
+    uint8_t jsr_h[] = {JSR, 0xD, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_h, 6);
+    // m->flags |= FLAG_HALT;
+    // m->sp += 0xA000;
+
+    // machine_step(m);
+
+    // munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_HALT));
+    // munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    // munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    // munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    // munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    // machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags &= ~FLAG_HALT;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_nh[] = {JSR, 0x5, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_nh, 6);
+    m->flags &= ~FLAG_HALT;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->flags |= FLAG_HALT;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE | FLAG_HALT));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_f[] = {JSR, 0xE, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_f, 6);
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    uint8_t jsr_nf[] = {JSR, 0x6, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_nf, 6);
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    uint8_t jsr_t[] = {JSR, 0xF, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_t, 6);
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 0xFACE);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA004);
+
+    machine_reset(m);
+
+    m->memory->data[0xA003] = 0x0;
+    uint8_t jsr_nt[] = {JSR, 0x7, 0xF, 0xA, 0xC, 0xE};
+    memcpy(m->memory->data, jsr_nt, 6);
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
+    machine_reset(m);
+
+    m->sp += 0xA000;
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, (FLAG_TRUE));
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+    munit_assert_uint8(m->memory->data[0xA000], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA001], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA002], ==, 0x0);
+    munit_assert_uint8(m->memory->data[0xA003], ==, 0x0);
+    munit_assert_ptr_equal(m->sp, m->memory->data + 0xA000);
+
     return MUNIT_OK;
 }
 
@@ -2262,8 +3073,10 @@ static MunitTest machine_cpu_exec_tests[] = {
      test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
     {(char *)"POP executes correctly", test_cpu_exec_pop, test_cpu_exec_setup,
      test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
-    // JMP
-    // JSR
+    {(char *)"JMP executes correctly", test_cpu_exec_jmp, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"JSR executes correctly", test_cpu_exec_jsr, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
     {(char *)"MOV executes correctly", test_cpu_exec_mov, test_cpu_exec_setup,
      test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
     {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};

--- a/src/test/test_cpu_exec.c
+++ b/src/test/test_cpu_exec.c
@@ -1,0 +1,1651 @@
+#include <memory.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../machine/cpu.h"
+#include "../munit/munit.h"
+#include "./test_cpu.h"
+
+static void *test_cpu_exec_setup(const MunitParameter params[], void *fixture) {
+    machine *m = machine_init(CPU_MAX_ADDRESS);
+    machine_start(m);
+
+    // General purpose registers should be zero
+    munit_assert_uint8(m->registers[0], ==, 0);
+    munit_assert_uint8(m->registers[1], ==, 0);
+    munit_assert_uint8(m->registers[2], ==, 0);
+    munit_assert_uint8(m->registers[3], ==, 0);
+    munit_assert_uint8(m->registers[4], ==, 0);
+    munit_assert_uint8(m->registers[5], ==, 0);
+
+    // Status flags should all be 0
+    munit_assert_uint8(m->flags, ==, 0x80);
+
+    return (void *)m;
+}
+
+static void test_cpu_exec_tear_down(void *fixture) {
+    machine *m = (machine *)fixture;
+    machine_free(m);
+}
+
+static void machine_step(machine *m) {
+    machine_instr_fetch(m);
+    machine_instr_decode(m);
+    machine_instr_execute(m);
+    machine_interrupt_check(m);
+}
+
+static MunitResult test_cpu_exec_nop(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+    uint8_t program[] = {NOP};
+    memcpy(m->memory->data, program, 1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_inc(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t inc_a[] = {INC, REGISTER_A};
+    memcpy(m->memory->data, inc_a, 2);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 2);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    // TODO Should flags update on INC / DEC?
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 2);
+
+    machine_reset(m);
+
+    uint8_t inc_sp[] = {INC, REGISTER_SP};
+    memcpy(m->memory->data, inc_sp, 2);
+    munit_assert_ptr_equal(m->sp, m->memory->data);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, m->memory->data + 1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 2);
+
+    machine_reset(m);
+
+    uint8_t inc_md[] = {INC, REGISTER_MD, 0x1, 0x0, 0x0, 0x0};
+    memcpy(m->memory->data, inc_md, 6);
+    munit_assert_uint8(m->memory->data[0x1000], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x1000], ==, 1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    machine_reset(m);
+
+    m->ix += 0xF000;
+    uint8_t inc_mx[] = {INC, REGISTER_MX, 0x0, 0x0, 0x0, 0xF};
+    memcpy(m->memory->data, inc_mx, 6);
+    munit_assert_uint8(m->ix[0x000F], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->ix[0x000F], ==, 1);
+    munit_assert_uint8(m->memory->data[0xF00F], ==, 1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 6);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_dec(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t dec_a[] = {DEC, REGISTER_A};
+    memcpy(m->memory->data, dec_a, 2);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 2);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xE);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 2);
+
+    machine_reset(m);
+
+    uint8_t dec_sp[] = {DEC, REGISTER_SP};
+    memcpy(m->memory->data, dec_sp, 2);
+    munit_assert_ptr_equal(m->sp, m->memory->data);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, m->memory->data - 1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 2);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_add(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t add_a_b[] = {ADD, REGISTER_A, REGISTER_B};
+    memcpy(m->memory->data, add_a_b, 3);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0x1;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+    // munit_assert_uint8(m->flags, ==, 0x8A);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1002;
+    uint8_t *sp = m->sp;
+    m->registers[REGISTER_F] = 0x8;
+    uint8_t add_sp_f[] = {ADD, REGISTER_SP, REGISTER_F};
+    memcpy(m->memory->data, add_sp_f, 3);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0xA);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1234;
+    sp = m->sp;
+    m->registers[REGISTER_C] = 0x6;
+    uint8_t add_c_sp[] = {ADD, REGISTER_C, REGISTER_SP};
+    memcpy(m->memory->data, add_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, sp + 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    uint8_t add_cv_d[] = {ADD, REGISTER_CV, REGISTER_D, 0x3};
+    m->registers[REGISTER_D] = 0x2;
+    memcpy(m->memory->data, add_cv_d, 4);
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x2);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x5);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 4);
+
+    machine_reset(m);
+
+    uint8_t add_cv_md[] = {ADD, REGISTER_CV, REGISTER_MD, 0x7,
+                           0x2, 0x0,         0x0,         0x0};
+    m->memory->data[0x2000] = 0x8;
+    memcpy(m->memory->data, add_cv_md, 8);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t add_cv_mx[] = {ADD, REGISTER_CV, REGISTER_MX, 0x7,
+                           0x0, 0x0,         0x2,         0x0};
+    m->ix += 0x2000;
+    m->memory->data[0x2020] = 0x8;
+    memcpy(m->memory->data, add_cv_mx, 8);
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t add_md_md[] = {ADD, REGISTER_MD, REGISTER_MD, 0x2, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->memory->data[0x2000] = 0x5;
+    m->memory->data[0x2001] = 0x6;
+    memcpy(m->memory->data, add_md_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xB);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t add_md_mx[] = {ADD, REGISTER_MD, REGISTER_MX, 0x2, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0xA;
+    m->memory->data[0x2001] = 0x4;
+    memcpy(m->memory->data, add_md_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xA);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x4);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xA);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xE);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t add_mx_md[] = {ADD, REGISTER_MX, REGISTER_MD, 0x0, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0xA;
+    m->memory->data[0x2001] = 0x4;
+    memcpy(m->memory->data, add_mx_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xA);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x4);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xA);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xE);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t add_mx_mx[] = {ADD, REGISTER_MX, REGISTER_MX, 0x0, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x2};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0xA;
+    m->memory->data[0x2002] = 0x4;
+    memcpy(m->memory->data, add_mx_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xA);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0x4);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xA);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xE);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_sub(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t sub_a_b[] = {SUB, REGISTER_A, REGISTER_B};
+    memcpy(m->memory->data, sub_a_b, 3);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0x0;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x1);
+    // munit_assert_uint8(m->flags, ==, 0x8A);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1002;
+    uint8_t *sp = m->sp;
+    m->registers[REGISTER_F] = 0x8;
+    uint8_t sub_sp_f[] = {SUB, REGISTER_SP, REGISTER_F};
+    memcpy(m->memory->data, sub_sp_f, 3);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1234;
+    sp = m->sp;
+    m->registers[REGISTER_C] = 0x6;
+    uint8_t sub_c_sp[] = {SUB, REGISTER_C, REGISTER_SP};
+    memcpy(m->memory->data, sub_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, sp - 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    uint8_t sub_cv_d[] = {SUB, REGISTER_CV, REGISTER_D, 0x3};
+    m->registers[REGISTER_D] = 0x5;
+    memcpy(m->memory->data, sub_cv_d, 4);
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x5);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x2);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 4);
+
+    machine_reset(m);
+
+    uint8_t sub_cv_md[] = {SUB, REGISTER_CV, REGISTER_MD, 0x7,
+                           0x2, 0x0,         0x0,         0x0};
+    m->memory->data[0x2000] = 0x8;
+    memcpy(m->memory->data, sub_cv_md, 8);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t sub_cv_mx[] = {SUB, REGISTER_CV, REGISTER_MX, 0x7,
+                           0x0, 0x0,         0x2,         0x0};
+    m->ix += 0x2000;
+    m->memory->data[0x2020] = 0x8;
+    memcpy(m->memory->data, sub_cv_mx, 8);
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0x1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t sub_md_md[] = {SUB, REGISTER_MD, REGISTER_MD, 0x2, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->memory->data[0x2000] = 0x6;
+    m->memory->data[0x2001] = 0xB;
+    memcpy(m->memory->data, sub_md_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x6);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xB);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x6);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x5);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t sub_md_mx[] = {SUB, REGISTER_MD, REGISTER_MX, 0x2, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, sub_md_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t sub_mx_md[] = {SUB, REGISTER_MX, REGISTER_MD, 0x0, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, sub_mx_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t sub_mx_mx[] = {SUB, REGISTER_MX, REGISTER_MX, 0x0, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x2};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2002] = 0xA;
+    memcpy(m->memory->data, sub_mx_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_rlc(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+    uint8_t program[] = {NOP};
+    memcpy(m->memory->data, program, 1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_rrc(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+    uint8_t program[] = {NOP};
+    memcpy(m->memory->data, program, 1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_and(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t and_a_b[] = {AND, REGISTER_A, REGISTER_B};
+    memcpy(m->memory->data, and_a_b, 3);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0x0;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x100F;
+    uint8_t *sp = m->sp;
+    m->registers[REGISTER_F] = 0xA;
+    uint8_t and_sp_f[] = {AND, REGISTER_SP, REGISTER_F};
+    memcpy(m->memory->data, and_sp_f, 3);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0xA);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    sp = m->sp;
+    m->sp += 0x1234;
+    m->registers[REGISTER_C] = 0xF;
+    uint8_t and_c_sp[] = {AND, REGISTER_C, REGISTER_SP};
+    memcpy(m->memory->data, and_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xF);
+    munit_assert_ptr_equal(m->sp, sp + 0x1234);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    sp = m->sp;
+    m->sp += 0x1234;
+    m->registers[REGISTER_C] = 0xB;
+    memcpy(m->memory->data, and_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xB);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xB);
+    munit_assert_ptr_equal(m->sp, sp + 0x1230);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    uint8_t and_cv_d[] = {AND, REGISTER_CV, REGISTER_D, 0x3};
+    m->registers[REGISTER_D] = 0x5;
+    memcpy(m->memory->data, and_cv_d, 4);
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x5);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x1);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 4);
+
+    machine_reset(m);
+
+    uint8_t and_cv_md[] = {AND, REGISTER_CV, REGISTER_MD, 0x7,
+                           0x2, 0x0,         0x0,         0x0};
+    m->memory->data[0x2000] = 0xE;
+    memcpy(m->memory->data, and_cv_md, 8);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xE);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t and_cv_mx[] = {AND, REGISTER_CV, REGISTER_MX, 0x7,
+                           0x0, 0x0,         0x2,         0x0};
+    m->ix += 0x2000;
+    m->memory->data[0x2020] = 0xE;
+    memcpy(m->memory->data, and_cv_mx, 8);
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0xE);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t and_md_md[] = {AND, REGISTER_MD, REGISTER_MD, 0x2, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->memory->data[0x2000] = 0x7;
+    m->memory->data[0x2001] = 0xE;
+    memcpy(m->memory->data, and_md_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xE);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t and_md_mx[] = {AND, REGISTER_MD, REGISTER_MX, 0x2, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x7;
+    m->memory->data[0x2001] = 0xE;
+    memcpy(m->memory->data, and_md_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xE);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t and_mx_md[] = {AND, REGISTER_MX, REGISTER_MD, 0x0, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x7;
+    m->memory->data[0x2001] = 0xE;
+    memcpy(m->memory->data, and_mx_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xE);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t and_mx_mx[] = {AND, REGISTER_MX, REGISTER_MX, 0x0, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x2};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x7;
+    m->memory->data[0x2002] = 0xE;
+    memcpy(m->memory->data, and_mx_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xE);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_or(const MunitParameter params[],
+                                    void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t or_a_b[] = {OR, REGISTER_A, REGISTER_B};
+    memcpy(m->memory->data, or_a_b, 3);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0x0;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0x0;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0x0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0x0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1003;
+    uint8_t *sp = m->sp;
+    m->registers[REGISTER_F] = 0xC;
+    uint8_t or_sp_f[] = {OR, REGISTER_SP, REGISTER_F};
+    memcpy(m->memory->data, or_sp_f, 3);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    sp = m->sp;
+    m->sp += 0x1233;
+    m->registers[REGISTER_C] = 0xC;
+    uint8_t or_c_sp[] = {OR, REGISTER_C, REGISTER_SP};
+    memcpy(m->memory->data, or_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xC);
+    munit_assert_ptr_equal(m->sp, sp + 0x123F);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    uint8_t or_cv_d[] = {OR, REGISTER_CV, REGISTER_D, 0x3};
+    m->registers[REGISTER_D] = 0xC;
+    memcpy(m->memory->data, or_cv_d, 4);
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 4);
+
+    machine_reset(m);
+
+    uint8_t or_cv_md[] = {OR,  REGISTER_CV, REGISTER_MD, 0x3,
+                          0x2, 0x0,         0x0,         0x0};
+    m->memory->data[0x2000] = 0xC;
+    memcpy(m->memory->data, or_cv_md, 8);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t or_cv_mx[] = {OR,  REGISTER_CV, REGISTER_MX, 0x3,
+                          0x0, 0x0,         0x2,         0x0};
+    m->ix += 0x2000;
+    m->memory->data[0x2020] = 0xC;
+    memcpy(m->memory->data, or_cv_mx, 8);
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t or_md_md[] = {OR,  REGISTER_MD, REGISTER_MD, 0x2, 0x0, 0x0,
+                          0x0, 0x2,         0x0,         0x0, 0x1};
+    m->memory->data[0x2000] = 0x3;
+    m->memory->data[0x2001] = 0xC;
+    memcpy(m->memory->data, or_md_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t or_md_mx[] = {OR,  REGISTER_MD, REGISTER_MX, 0x2, 0x0, 0x0,
+                          0x0, 0x0,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x3;
+    m->memory->data[0x2001] = 0xC;
+    memcpy(m->memory->data, or_md_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t or_mx_md[] = {OR,  REGISTER_MX, REGISTER_MD, 0x0, 0x0, 0x0,
+                          0x0, 0x2,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x3;
+    m->memory->data[0x2001] = 0xF;
+    memcpy(m->memory->data, or_mx_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t or_mx_mx[] = {OR,  REGISTER_MX, REGISTER_MX, 0x0, 0x0, 0x0,
+                          0x0, 0x0,         0x0,         0x0, 0x2};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x3;
+    m->memory->data[0x2002] = 0xC;
+    memcpy(m->memory->data, or_mx_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xC);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x3);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_xor(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t xor_a_b[] = {XOR, REGISTER_A, REGISTER_B};
+    memcpy(m->memory->data, xor_a_b, 3);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0x0;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1005;
+    uint8_t *sp = m->sp;
+    m->registers[REGISTER_F] = 0xA;
+    uint8_t xor_sp_f[] = {XOR, REGISTER_SP, REGISTER_F};
+    memcpy(m->memory->data, xor_sp_f, 3);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    sp = m->sp;
+    m->sp += 0x1235;
+    m->registers[REGISTER_C] = 0xA;
+    uint8_t xor_c_sp[] = {XOR, REGISTER_C, REGISTER_SP};
+    memcpy(m->memory->data, xor_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0xA);
+    munit_assert_ptr_equal(m->sp, sp + 0x123F);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    uint8_t xor_cv_d[] = {XOR, REGISTER_CV, REGISTER_D, 0xA};
+    m->registers[REGISTER_D] = 0x5;
+    memcpy(m->memory->data, xor_cv_d, 4);
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x5);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 4);
+
+    machine_reset(m);
+
+    uint8_t xor_cv_md[] = {XOR, REGISTER_CV, REGISTER_MD, 0xA,
+                           0x2, 0x0,         0x0,         0x0};
+    m->memory->data[0x2000] = 0x5;
+    memcpy(m->memory->data, xor_cv_md, 8);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t xor_cv_mx[] = {XOR, REGISTER_CV, REGISTER_MX, 0xA,
+                           0x0, 0x0,         0x2,         0x0};
+    m->ix += 0x2000;
+    m->memory->data[0x2020] = 0x5;
+    memcpy(m->memory->data, xor_cv_mx, 8);
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0x5);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t xor_md_md[] = {XOR, REGISTER_MD, REGISTER_MD, 0x2, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->memory->data[0x2000] = 0x5;
+    m->memory->data[0x2001] = 0xF;
+    memcpy(m->memory->data, xor_md_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t xor_md_mx[] = {XOR, REGISTER_MD, REGISTER_MX, 0x2, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x5;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, xor_md_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t xor_mx_md[] = {XOR, REGISTER_MX, REGISTER_MD, 0x0, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x5;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, xor_mx_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t xor_mx_mx[] = {XOR, REGISTER_MX, REGISTER_MX, 0x0, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x2};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x5;
+    m->memory->data[0x2002] = 0xA;
+    memcpy(m->memory->data, xor_mx_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x5);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_cmp(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t cmp_a_b[] = {CMP, REGISTER_A, REGISTER_B};
+    memcpy(m->memory->data, cmp_a_b, 3);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0x0;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+    munit_assert_uint8(m->flags, ==, 0x81);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0x0;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0x0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0x0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1002;
+    uint8_t *sp = m->sp;
+    m->registers[REGISTER_F] = 0x8;
+    uint8_t cmp_sp_f[] = {CMP, REGISTER_SP, REGISTER_F};
+    memcpy(m->memory->data, cmp_sp_f, 3);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0x8);
+    munit_assert_uint8(m->flags, ==, 0xA0);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1234;
+    sp = m->sp;
+    m->registers[REGISTER_C] = 0x6;
+    uint8_t cmp_c_sp[] = {CMP, REGISTER_C, REGISTER_SP};
+    memcpy(m->memory->data, cmp_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->flags, ==, 0xA0);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    uint8_t cmp_cv_d[] = {CMP, REGISTER_CV, REGISTER_D, 0x3};
+    m->registers[REGISTER_D] = 0x5;
+    memcpy(m->memory->data, cmp_cv_d, 4);
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x5);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x5);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 4);
+
+    machine_reset(m);
+
+    uint8_t cmp_cv_md[] = {CMP, REGISTER_CV, REGISTER_MD, 0x8,
+                           0x2, 0x0,         0x0,         0x0};
+    m->memory->data[0x2000] = 0x7;
+    memcpy(m->memory->data, cmp_cv_md, 8);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+    munit_assert_uint8(m->flags, ==, 0x81);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t cmp_cv_mx[] = {CMP, REGISTER_CV, REGISTER_MX, 0x8,
+                           0x0, 0x0,         0x2,         0x0};
+    m->ix += 0x2000;
+    m->memory->data[0x2020] = 0x8;
+    memcpy(m->memory->data, cmp_cv_mx, 8);
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0x8);
+    munit_assert_uint8(m->flags, ==, 0x82);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t cmp_md_md[] = {CMP, REGISTER_MD, REGISTER_MD, 0x2, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->memory->data[0x2000] = 0x6;
+    m->memory->data[0x2001] = 0xB;
+    memcpy(m->memory->data, cmp_md_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x6);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xB);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x6);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xB);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t cmp_md_mx[] = {CMP, REGISTER_MD, REGISTER_MX, 0x2, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, cmp_md_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t cmp_mx_md[] = {CMP, REGISTER_MX, REGISTER_MD, 0x0, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, cmp_mx_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t cmp_mx_mx[] = {CMP, REGISTER_MX, REGISTER_MX, 0x0, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x2};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2002] = 0xA;
+    memcpy(m->memory->data, cmp_mx_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xA);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_psh(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+    uint8_t program[] = {NOP};
+    memcpy(m->memory->data, program, 1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_pop(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+    uint8_t program[] = {NOP};
+    memcpy(m->memory->data, program, 1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_jmp(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+    uint8_t program[] = {NOP};
+    memcpy(m->memory->data, program, 1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_jsr(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+    uint8_t program[] = {NOP};
+    memcpy(m->memory->data, program, 1);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 1);
+    return MUNIT_OK;
+}
+
+static MunitResult test_cpu_exec_mov(const MunitParameter params[],
+                                     void *fixture) {
+    machine *m = (machine *)fixture;
+
+    uint8_t mov_a_b[] = {MOV, REGISTER_A, REGISTER_B};
+    memcpy(m->memory->data, mov_a_b, 3);
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0xF;
+    m->registers[REGISTER_B] = 0x0;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0xF);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->registers[REGISTER_A] = 0x0;
+    m->registers[REGISTER_B] = 0xF;
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0x0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0xF);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_A], ==, 0x0);
+    munit_assert_uint8(m->registers[REGISTER_B], ==, 0x0);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    m->sp += 0x1002;
+    uint8_t *sp = m->sp;
+    m->registers[REGISTER_F] = 0x8;
+    uint8_t mov_sp_f[] = {MOV, REGISTER_SP, REGISTER_F};
+    memcpy(m->memory->data, mov_sp_f, 3);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0x8);
+
+    machine_step(m);
+
+    munit_assert_ptr_equal(m->sp, sp);
+    munit_assert_uint8(m->registers[REGISTER_F], ==, 0x2);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    sp = m->sp;
+    m->sp += 0x1234;
+    m->registers[REGISTER_C] = 0x6;
+    uint8_t mov_c_sp[] = {MOV, REGISTER_C, REGISTER_SP};
+    memcpy(m->memory->data, mov_c_sp, 3);
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_C], ==, 0x6);
+    munit_assert_ptr_equal(m->sp, sp + 0x1236);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 3);
+
+    machine_reset(m);
+
+    uint8_t mov_cv_d[] = {MOV, REGISTER_CV, REGISTER_D, 0x3};
+    m->registers[REGISTER_D] = 0x5;
+    memcpy(m->memory->data, mov_cv_d, 4);
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x5);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->registers[REGISTER_D], ==, 0x3);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 4);
+
+    machine_reset(m);
+
+    uint8_t mov_cv_md[] = {MOV, REGISTER_CV, REGISTER_MD, 0x8,
+                           0x2, 0x0,         0x0,         0x0};
+    m->memory->data[0x2000] = 0x7;
+    memcpy(m->memory->data, mov_cv_md, 8);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x7);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x8);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t mov_cv_mx[] = {MOV, REGISTER_CV, REGISTER_MX, 0xF,
+                           0x0, 0x0,         0x2,         0x0};
+    m->ix += 0x2000;
+    m->memory->data[0x2020] = 0xA;
+    memcpy(m->memory->data, mov_cv_mx, 8);
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2020], ==, 0xF);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 8);
+
+    machine_reset(m);
+
+    uint8_t mov_md_md[] = {MOV, REGISTER_MD, REGISTER_MD, 0x2, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->memory->data[0x2000] = 0x6;
+    m->memory->data[0x2001] = 0xB;
+    memcpy(m->memory->data, mov_md_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x6);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xB);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x6);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x6);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t mov_md_mx[] = {MOV, REGISTER_MD, REGISTER_MX, 0x2, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, mov_md_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x4);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t mov_mx_md[] = {MOV, REGISTER_MX, REGISTER_MD, 0x0, 0x0, 0x0,
+                           0x0, 0x2,         0x0,         0x0, 0x1};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2001] = 0xA;
+    memcpy(m->memory->data, mov_mx_md, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2001], ==, 0x4);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    machine_reset(m);
+
+    uint8_t mov_mx_mx[] = {MOV, REGISTER_MX, REGISTER_MX, 0x0, 0x0, 0x0,
+                           0x0, 0x0,         0x0,         0x0, 0x2};
+    m->ix += 0x2000;
+    m->memory->data[0x2000] = 0x4;
+    m->memory->data[0x2002] = 0xA;
+    memcpy(m->memory->data, mov_mx_mx, 11);
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0xA);
+
+    machine_step(m);
+
+    munit_assert_uint8(m->memory->data[0x2000], ==, 0x4);
+    munit_assert_uint8(m->memory->data[0x2002], ==, 0x4);
+    munit_assert_uint8(m->flags, ==, 0x80);
+    munit_assert_ptr_equal(m->pc, m->memory->data + 11);
+
+    return MUNIT_OK;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+static MunitTest machine_cpu_exec_tests[] = {
+    {(char *)"NOP executes correctly", test_cpu_exec_nop, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"INC executes correctly", test_cpu_exec_inc, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"ADD executes correctly", test_cpu_exec_add, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"SUB executes correctly", test_cpu_exec_sub, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    // RLC
+    // RRC
+    {(char *)"AND executes correctly", test_cpu_exec_and, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)" OR executes correctly", test_cpu_exec_or, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"XOR executes correctly", test_cpu_exec_xor, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {(char *)"CMP executes correctly", test_cpu_exec_cmp, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    // PSH
+    // POP
+    // JMP
+    // JSR
+    {(char *)"MOV executes correctly", test_cpu_exec_mov, test_cpu_exec_setup,
+     test_cpu_exec_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Adds CPU execution tests for all opcodes. In the course of writing tests, the following bugs were discovered and fixed:

- Flag registers correctly update by masking existing values when changing upper or lower nibbles
- The `CMP` opcode halts the CPU when operand widths don't match